### PR TITLE
Remove -fdebug-prefix-map option in rules.mk

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -52,7 +52,7 @@ ifdef CONFIG_WITH_ARCH
 endif
 
 # Debug options
-CORE_CFLAGS+=-g3 -fdebug-prefix-map=/= -DDEBUG -pipe -grecord-gcc-switches
+CORE_CFLAGS+=-g3 -DDEBUG -pipe -grecord-gcc-switches
 
 
 # Warning / Code Quality


### PR DESCRIPTION
It is inappropriate to leave a build option (-fdebug-prefix-map)
just for a specific debug configuration in the make rules, as it
will cause a non-working debug configuration for someone else.

Signed-off-by: Bin Meng <bin.meng@windriver.com>