### PR TITLE
Fix .srodata and .sdata2 in linker scripts

### DIFF
--- a/boards/icicle-kit-es/hss-envm.ld
+++ b/boards/icicle-kit-es/hss-envm.ld
@@ -164,6 +164,8 @@ SECTIONS
         KEEP (*crtend.o(.dtors))
 
         *(.rodata .rodata.* .gnu.linkonce.r.*)
+        *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2)
+        *(.srodata*)
         *(.sdata2.*)
         *(.gcc_except_table)
         *(.eh_frame_hdr)
@@ -244,8 +246,6 @@ SECTIONS
          * Perhaps we should add check/warning to linker script if sdata is > 4k
          */
         __global_pointer$ = . + 0x800;
-        *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2)
-        *(.srodata*)
         *(.sdata .sdata.* .gnu.linkonce.s.*)
         . = ALIGN(0x10);
         __sdata_end = .;

--- a/boards/icicle-kit-es/hss-l2lim.ld
+++ b/boards/icicle-kit-es/hss-l2lim.ld
@@ -161,6 +161,9 @@ SECTIONS
         KEEP (*crtend.o(.dtors))
 
         *(.rodata .rodata.* .gnu.linkonce.r.*)
+        *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2)
+        *(.srodata*)
+        *(.sdata2.*)
         *(.gcc_except_table)
         *(.eh_frame_hdr)
         *(.eh_frame)
@@ -240,9 +243,7 @@ SECTIONS
          * Perhaps we should add check/warning to linker script if sdata is > 4k
          */
         __global_pointer$ = . + 0x800;
-        *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2)
-        *(.srodata*)
-        *(.sdata .sdata2.* .sdata.* .gnu.linkonce.s.*)
+        *(.sdata .sdata.* .gnu.linkonce.s.*)
         . = ALIGN(0x10);
         __sdata_end = .;
     } >l2lim

--- a/boards/icicle-kit-es/hss.ld
+++ b/boards/icicle-kit-es/hss.ld
@@ -164,6 +164,8 @@ SECTIONS
         KEEP (*crtend.o(.dtors))
 
         *(.rodata .rodata.* .gnu.linkonce.r.*)
+        *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2)
+        *(.srodata*)
         *(.sdata2.*)
         *(.gcc_except_table)
         *(.eh_frame_hdr)
@@ -244,8 +246,6 @@ SECTIONS
          * Perhaps we should add check/warning to linker script if sdata is > 4k
          */
         __global_pointer$ = . + 0x800;
-        *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2)
-        *(.srodata*)
         *(.sdata .sdata.* .gnu.linkonce.s.*)
         . = ALIGN(0x10);
         __sdata_end = .;

--- a/boards/lc-mpfs/hss.ld
+++ b/boards/lc-mpfs/hss.ld
@@ -92,6 +92,9 @@ SECTIONS
         KEEP (*crtend.o(.dtors))
 
         *(.rodata .rodata.* .gnu.linkonce.r.*)
+        *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2)
+        *(.srodata*)
+        *(.sdata2.*)
         *(.gcc_except_table)
         *(.eh_frame_hdr)
         *(.eh_frame)
@@ -172,9 +175,7 @@ SECTIONS
          * Perhaps we should add check/warning to linker script if sdata is > 4k
          */
         __global_pointer$ = . + 0x800;
-        *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2)
-        *(.srodata*)
-        *(.sdata .sdata2.* .sdata.* .gnu.linkonce.s.*)
+        *(.sdata .sdata.* .gnu.linkonce.s.*)
         . = ALIGN(0x10);
         __sdata_end = .;
     } 

--- a/boards/mpfs/hss.ld
+++ b/boards/mpfs/hss.ld
@@ -92,6 +92,9 @@ SECTIONS
         KEEP (*crtend.o(.dtors))
 
         *(.rodata .rodata.* .gnu.linkonce.r.*)
+        *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2)
+        *(.srodata*)
+        *(.sdata2.*)
         *(.gcc_except_table)
         *(.eh_frame_hdr)
         *(.eh_frame)
@@ -172,9 +175,7 @@ SECTIONS
          * Perhaps we should add check/warning to linker script if sdata is > 4k
          */
         __global_pointer$ = . + 0x800;
-        *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2)
-        *(.srodata*)
-        *(.sdata .sdata2.* .sdata.* .gnu.linkonce.s.*)
+        *(.sdata .sdata.* .gnu.linkonce.s.*)
         . = ALIGN(0x10);
         __sdata_end = .;
     } 


### PR DESCRIPTION
.srodata should really be in the .text section. .sdata2 should be
in the .text section too, as GCC 9 seems to put some variables in
that section instead of .srodata.

This fixes an issue as seen with image built by GCC 10.1.0, that
globalInitFunctions and spanOfGlobalInitFunctions variables are
put in .srodata which ends up being in the L2LIM address range,
but at that time L2LIM contains all zeroes, causing boot failures.

Signed-off-by: Bin Meng <bin.meng@windriver.com>