### PR TITLE
Fix potential typo (my_ vs hss_init_)

### DIFF
--- a/hss_init.c
+++ b/hss_init.c
@@ -96,7 +96,7 @@ extern const uint64_t __ddr_start,        __ddr_end;
 //  #define DDR_END                (&__ddr_end)
 asm(".align 3\n"
     "hss_init_ddr_end: .quad (__ddr_end)\n"
-    ".globl   my_ddr_end\n");
+    ".globl   hss_init_ddr_end\n");
 extern const uint64_t hss_init_ddr_end;
 #define DDR_END                (&hss_init_ddr_end)
 


### PR DESCRIPTION
my_ddr_end is not referenced anywhere else, while hss_init_ddr_end is used