### PR TITLE
Explicitly specify the compiler flags for RISC-V arch & abi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,11 +127,7 @@ EXTRA_SRCS-y += misc/stack_guard.c
 ifdef CONFIG_OPENSBI
   OPENSBI_LIBS = thirdparty/opensbi/build/lib/libsbi.a
   $(OPENSBI_LIBS):
-ifdef CONFIG_WITH_ARCH
-	+$(CMD_PREFIX)$(MAKE) CROSS_COMPILE=$(CROSS_COMPILE) CONFIG_WITH_ARCH=$(CONFIG_WITH_ARCH) PLATFORM_RISCV_ABI=$(PLATFORM_RISCV_ABI) PLATFORM_RISCV_ISA=$(PLATFORM_RISCV_ISA) -r --no-print-directory -C thirdparty/opensbi V=$(V)
-else
-	+$(CMD_PREFIX)$(MAKE) CROSS_COMPILE=$(CROSS_COMPILE) -r --no-print-directory -C thirdparty/opensbi V=$(V)
-endif
+	+$(CMD_PREFIX)$(MAKE) CROSS_COMPILE=$(CROSS_COMPILE) PLATFORM_RISCV_ABI=$(PLATFORM_RISCV_ABI) PLATFORM_RISCV_ISA=$(PLATFORM_RISCV_ISA) -r --no-print-directory -C thirdparty/opensbi V=$(V)
 
   .PHONY: $(OPENSBI_LIBS)
 else

--- a/rules.mk
+++ b/rules.mk
@@ -47,9 +47,7 @@ PLATFORM_RISCV_ISA=rv64imac
 
 CORE_CFLAGS+=$(MCMODEL) -mstrict-align
 
-ifdef CONFIG_WITH_ARCH
-  CORE_CFLAGS+=-mabi=$(PLATFORM_RISCV_ABI) -march=$(PLATFORM_RISCV_ISA)
-endif
+CORE_CFLAGS+=-mabi=$(PLATFORM_RISCV_ABI) -march=$(PLATFORM_RISCV_ISA)
 
 # Debug options
 CORE_CFLAGS+=-g3 -DDEBUG -pipe -grecord-gcc-switches

--- a/thirdparty/opensbi/Makefile
+++ b/thirdparty/opensbi/Makefile
@@ -199,9 +199,7 @@ GENFLAGS	+=	$(firmware-genflags-y)
 CFLAGS		=	-g -Wall -Werror -ffreestanding -nostdlib -fno-strict-aliasing -O2
 CFLAGS		+=	-fno-omit-frame-pointer -fno-optimize-sibling-calls
 CFLAGS		+=	-mno-save-restore -mstrict-align
-ifdef CONFIG_WITH_ARCH
 CFLAGS		+=	-mabi=$(PLATFORM_RISCV_ABI) -march=$(PLATFORM_RISCV_ISA)
-endif
 CFLAGS		+=	-mcmodel=$(PLATFORM_RISCV_CODE_MODEL)
 CFLAGS		+=	$(GENFLAGS)
 CFLAGS		+=	$(platform-cflags-y)
@@ -215,9 +213,7 @@ CPPFLAGS	+=	$(firmware-cppflags-y)
 ASFLAGS		=	-g -Wall -nostdlib -D__ASSEMBLY__
 ASFLAGS		+=	-fno-omit-frame-pointer -fno-optimize-sibling-calls
 ASFLAGS		+=	-mno-save-restore -mstrict-align
-ifdef CONFIG_WITH_ARCH
 ASFLAGS		+=	-mabi=$(PLATFORM_RISCV_ABI) -march=$(PLATFORM_RISCV_ISA)
-endif
 ASFLAGS		+=	-mcmodel=$(PLATFORM_RISCV_CODE_MODEL)
 ASFLAGS		+=	$(GENFLAGS)
 ASFLAGS		+=	$(platform-asflags-y)


### PR DESCRIPTION
We should not depend on the toolchain default settings for the RISC-V
arch and abi. Instead we should explicitly specify them.

Current makefiles use an undocumented CONFIG_WITH_ARCH shell variable
to pass arch & abi during build, but this should not be a user choice.

This resolves the link error as seen with the bootlin toolchain.

Fixes: https://github.com/polarfire-soc/hart-software-services/issues/19
Signed-off-by: Bin Meng <bmeng.cn@gmail.com>