### PR TITLE
Adding GitHub Action which will build the HSS on each push

### DIFF
--- a/.github/workflows/build-hss.yaml
+++ b/.github/workflows/build-hss.yaml
@@ -1,0 +1,9 @@
+on: [push]
+jobs:
+  build-hss:
+    runs-on: ubuntu-latest
+    container: microsemiproess/softconsole-headless-slim:6.6-2021.1-hss
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - run: cp boards/mpfs-icicle-kit-es/def_config .config && make BOARD=mpfs-icicle-kit-es && ls -la ./Default

--- a/.github/workflows/build-hss.yaml
+++ b/.github/workflows/build-hss.yaml
@@ -6,4 +6,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
-      - run: cp boards/mpfs-icicle-kit-es/def_config .config && make BOARD=mpfs-icicle-kit-es && ls -la ./Default
+      - run: cp boards/mpfs-icicle-kit-es/def_config .config
+      - run: make BOARD=mpfs-icicle-kit-es
+      - run: ls -la ./Default


### PR DESCRIPTION
# Sanity checking and usability improvement

GitHub action inside this PR provides the following:
 - Quick sanity check that the project builds with the given commit. Example: https://github.com/AntonKrug/hart-software-services/runs/2774766601?check_suite_focus=true#step:6:1
 - Automatically runs the build script on each push.
 - Tests the SoftConsole container itself that it's capable to build HSS.
 - Quick way to switch between versions. A newer toolchain needed which is shipped with a newer SoftConsole? Just change the `tag` in the `container` line.
 - Will allow quick PR evaluation, see if the changes break the build before starting the review process.

What it could enable us in the future:
 - Having separate instructions in the Readme for the Docker users who will not need to install anything else. No need to install kconfiglib or any other tools except docker, and should improve the user experience for Windows users (installing one tool 'Docker' that is proven to build reliable artifacts should be easier than the installation of msys/cygwin/mingw/python). 
 - Allow us to expand the GitHub action and have builds done for a handful of predetermined configs instead of just one.
 - Attach built artifacts to the releases automatically and have these handfuls of configs already pre-build with each release, further eliminating the need to do an HSS build themselves (especially for the first time users who do not need any custom config)