### PR TITLE
hss-payload-generator: avoid OpenSSL deprecation warning

### DIFF
--- a/tools/hss-payload-generator/generate_payload.c
+++ b/tools/hss-payload-generator/generate_payload.c
@@ -27,6 +27,7 @@
  */
 
 #define _FILE_OFFSET_BITS 64
+#define OPENSSL_API_COMPAT 0x10101000L
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
With OpenSSL 3.0 deprecation warnings occur which are treated as errors.

With the patch compatibility with OpenSSL 1.1.1 is declared.

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>