### PR TITLE
Boot hss over jtag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 .config.old
 config.h
 include/tool_versions.h
+Default/run-hss.cfg

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ DEPENDENCIES+=include/tool_versions.h
 endif
 
 include envm-wrapper/Makefile
+include jtag_trampoline/Makefile
 
 ################################################################################################
 #

--- a/application/hart0/hss_main.c
+++ b/application/hart0/hss_main.c
@@ -74,11 +74,11 @@ int main(int argc, char **argv)
     (void)argc; // unused
     (void)argv; // unused
 
-    HSS_Init();
-
     if (current_hartid() != 0) {
         sbi_hart_hang();
     }
+
+    HSS_Init();
 
     hss_main();
 

--- a/boards/mpfs-icicle-kit-es/Makefile
+++ b/boards/mpfs-icicle-kit-es/Makefile
@@ -32,7 +32,8 @@ $(info mpfs-icicle-kit-es selected)
 BINDIR=Default
 TARGET-l2scratch=hss-l2scratch.elf
 TARGET-envm-wrapper=hss-envm-wrapper.elf
-RISCV_TARGET=$(TARGET-l2scratch) $(TARGET-envm-wrapper)
+TARGET-jtag_trampoline=hss-jtag_trampoline.elf
+RISCV_TARGET=$(TARGET-l2scratch) $(TARGET-envm-wrapper) $(TARGET-jtag_trampoline)
 TARGET:=$(RISCV_TARGET)
 
 LINKER_SCRIPT-l2scratch=boards/${BOARD}/hss-l2scratch.ld

--- a/jtag_trampoline/Makefile
+++ b/jtag_trampoline/Makefile
@@ -1,0 +1,71 @@
+#
+# MPFS HSS Embedded Software
+#
+# Copyright 2019-2021 Microchip Corporation.
+#
+# SPDX-License-Identifier: MIT
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+#
+# Boot HSS over JTAG trampoline
+
+
+OBJS-jtag_trampoline = \
+	jtag_trampoline/jtag_trampoline_crt.o \
+	jtag_trampoline/jtag_trampoline_funcs.o \
+	baremetal/polarfire-soc-bare-metal-library/src/platform/mpfs_hal/common/mss_l2_cache.o \
+	baremetal/polarfire-soc-bare-metal-library/src/platform/mpfs_hal/common/nwc/mss_nwc_init.o \
+	baremetal/polarfire-soc-bare-metal-library/src/platform/mpfs_hal/common/nwc/mss_pll.o \
+    baremetal/polarfire-soc-bare-metal-library/src/platform/mpfs_hal/common/nwc/mss_io.o \
+	baremetal/polarfire-soc-bare-metal-library/src/platform/mpfs_hal/common/nwc/mss_sgmii.o \
+	baremetal/polarfire-soc-bare-metal-library/src/platform/mpfs_hal/common/mss_peripherals.o \
+	baremetal/polarfire-soc-bare-metal-library/src/platform/mpfs_hal/startup_gcc/mss_utils.o \
+	baremetal/polarfire-soc-bare-metal-library/src/platform/drivers/mss/mss_mmuart/mss_uart.o
+
+EXTRA_OBJS-jtag_trampoline=
+
+LINKER_SCRIPT-jtag_trampoline = jtag_trampoline/jtag_trampoline.ld
+
+jtag_trampoline/jtag_trampoline_crc.o: CFLAGS=$(CFLAGS_GCCEXT)
+jtag_trampoline/jtag_trampoline_funcs.o: CFLAGS=$(CFLAGS_GCCEXT)
+
+$(TARGET-jtag_trampoline): LIBS:=
+$(TARGET-jtag_trampoline): $(OBJS-jtag_trampoline) $(BINDIR)/run-hss.cfg
+	$(call main-build-target,jtag_trampoline)
+	@$(ECHO) " HEX       `basename $@ .elf`.hex";
+	$(OBJCOPY) -O ihex $(BINDIR)/$@ $(BINDIR)/`basename $@ .elf`.hex
+	$(SIZE) $(BINDIR)/$(TARGET-jtag_trampoline) 2>/dev/null
+
+jtag_trampoline_clean:
+	-$(RM) $(COMPRESSED_TARGET) $(OBJS-jtag_trampoline) $(BINDIR)/$(TARGET-jtag_trampoline) $(BINDIR)/`basename $(TARGET-jtag_trampoline) .elf`.sym $(BINDIR)/`basename $(TARGET-jtag_trampoline) .elf`.bin
+
+HEX_FILE-jtag_trampoline=$(BINDIR)/$(TARGET-jtag_trampoline:.elf=.hex)
+BIN_FILE-jtag_trampoline=$(BINDIR)/$(TARGET-jtag_trampoline:.elf=.bin)
+
+BIN_FILE-jtag_trampoline: $(TARGET-jtag_trampoline)
+
+COPY_CMD := cp
+
+ifeq ($(OS),Windows_NT)
+	COPY_CMD := cmd /c copy
+endif
+
+$(BINDIR)/run-hss.cfg: jtag_trampoline/run-hss.cfg
+	$(SHELL) -c "cp jtag_trampoline/run-hss.cfg $(BINDIR)/run-hss.cfg"

--- a/jtag_trampoline/README.md
+++ b/jtag_trampoline/README.md
@@ -1,0 +1,18 @@
+# HSS-over-JTAG
+During development it might be useful to run HSS in boot mode 0 and without need to write HSS executable to eNVM. HSS itself is running from L2 scratchpad but there are some initialization steps required for HSS to execute correctly. In bootmodes 1..3 that initialization is performed by `envm-wrapper`. In bootmode 0 `jtag_trampoline` with OpenOCD script can be used to achieve the same results.
+
+## Running HSS-over-JTAG
+1. Build HSS binaries.
+2. Connect debug adapter to target
+3. Execute OpenOCD command: `openocd -f <init script> -c "set HSS_DIR <hart-software-services>/Default" -f <hart-software-services>/Default/run-hss.cfg`
+4. HSS will be started
+
+
+## Details of operation
+1. `hss-jtag_trampoline.hex` is loaded into E51 DTIM and E51 ITIM memories
+2. Harts are resumed starting from address `0x01800000` (E51 ITIM). OpenOCD hangs on `wait_halt` command.
+3. HSS initialization steps are performed: L2 scratchpad configuration, clocks setups
+4. `ebreak` instruction is invoked. OpenOCD command `wait_halt` ends and resumes script.
+5. `hss-l2scratch.bin` is loaded into L2 scratchpad area.
+6. Harts are resumed from address `0x0A000000`.
+7. HSS is running

--- a/jtag_trampoline/jtag_trampoline.ld
+++ b/jtag_trampoline/jtag_trampoline.ld
@@ -1,0 +1,263 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * MPFS HAL Embedded Software
+ *
+ */
+/*******************************************************************************
+ *
+ * file name : mpfs_lim.ld
+ * Used when debugging code. The debugger loads the code to LIM.
+ *
+ * You can find details on the PolarFireSoC Memory map in the mpfs-memory-hierarchy.md
+ * which can be found under the link below:
+ * https://github.com/polarfire-soc/polarfire-soc-documentation
+ *
+ */
+
+OUTPUT_ARCH( "riscv" )
+ENTRY(_start)
+
+/*-----------------------------------------------------------------------------
+
+-- MSS hart Reset vector
+
+The MSS reset vector for each hart is stored securely in the MPFS.
+The most common usage will be where the reset vector for each hart will be set
+to the start of the envm at address 0x2022_0100, giving 128K-256B of contiguous
+non-volatile storage. Normally this is where the initial boot-loader will
+reside. (Note: The first 256B page of envm is used for metadata associated with
+secure boot. When not using secure boot (mode 0,1), this area is still reserved
+by convention. It allows easier transition from non-secure to secure boot flow
+during the development process.
+When debugging a bare metal program that is run out of reset from envm, a linker
+script will be used whereby the program will run from LIM instead of envm.
+In this case, the reset vector in the linker script is normally set to the
+start of LIM, 0x0800_0000.
+This means you are not continually programming the envm each time you load a
+program and there is no limitation with break points when debugging.
+See the mpfs-lim.ld example linker script when runing from LIM.
+
+
+------------------------------------------------------------------------------*/
+
+MEMORY
+{
+    dtim (rwx) : ORIGIN = 0x01000000, LENGTH = 8k
+    e51_itim (rwx) : ORIGIN = 0x01800000, LENGTH = 28k
+    scratchpad(rwx)  : ORIGIN = 0x0A000000, LENGTH = 256k
+
+    l2lim (rwx) : ORIGIN = 0x08000000, LENGTH = 512k
+    l2zerodevice (rwx) : ORIGIN = 0x0A000000, LENGTH = 512k
+}
+
+HEAP_SIZE           = 0k;               /* needs to be calculated for your application if using */
+PROVIDE(STACK_SIZE_PER_HART = 4k);
+
+PROVIDE(__sc_load = 0);
+PROVIDE(__sc_start = 0);
+PROVIDE(__sc_end = 0);
+
+/* STACK_SIZE_PER_HART needs to be calculated for your */
+/* application. Must be aligned */
+/* Also Thread local storage (AKA hart local storage) allocated for each hart */
+/* as part of the stack
+/* So memory map will look like once apportion in startup code: */
+/*   */
+/* stack hart0  Actual Stack size = (STACK_SIZE_PER_HART - HLS_DEBUG_AREA_SIZE) */
+/* TLS hart 0   */
+/* stack hart1  */
+/* TLS hart 1   */
+/* etc */
+/* note: HLS_DEBUG_AREA_SIZE is defined in mss_sw_config.h */
+/* STACK_SIZE_PER_HART = 8k; */
+
+/*
+ * There is common area for shared variables, accessed from a pointer in a harts HLS
+ */
+SIZE_OF_COMMON_HART_MEM = 128;
+
+/*
+ * Stack size for each hart's application.
+ * These are the stack sizes that will be allocated to each hart before starting
+ * each hart's application function, e51(), u54_1(), u54_2(), u54_3(), u54_4().
+ */
+STACK_SIZE_E51_APPLICATION = 2k;
+
+
+SECTIONS
+{
+    PROVIDE(__dtim_start = ORIGIN(dtim));
+    PROVIDE(__dtim_end = ORIGIN(dtim) + LENGTH(dtim));
+    PROVIDE(__e51itim_start = ORIGIN(e51_itim));
+    PROVIDE(__e51itim_end = ORIGIN(e51_itim) + LENGTH(e51_itim));
+
+    PROVIDE(__l2lim_start = ORIGIN(l2lim));
+    PROVIDE(__l2lim_end = ORIGIN(l2lim) + LENGTH(l2lim));
+    PROVIDE(__l2_start = ORIGIN(l2zerodevice));
+    PROVIDE(__l2_end = ORIGIN(l2zerodevice) + LENGTH(l2zerodevice));
+
+    /* text: text code section */
+
+    .text : ALIGN(0x10)
+    {
+        __text_load = LOADADDR(.text);
+        __text_start = .;
+        *(.entry)
+         *(.text.init)
+        . = ALIGN(0x10);
+        *(.text .text.* .gnu.linkonce.t.*)
+        *(.plt)
+        . = ALIGN(0x10);
+
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*crtend.o(.ctors))
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*crtend.o(.dtors))
+
+        *(.rodata .rodata.* .gnu.linkonce.r.*)
+        *(.sdata2 .sdata2.* .gnu.linkonce.s2.*)
+        *(.gcc_except_table)
+        *(.eh_frame_hdr)
+        *(.eh_frame)
+
+        KEEP (*(.init))
+        KEEP (*(.fini))
+
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP (*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array))
+        PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP (*(.fini_array))
+        KEEP (*(SORT(.fini_array.*)))
+        PROVIDE_HIDDEN (__fini_array_end = .);
+
+        *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2)
+        *(.srodata*)
+
+        . = ALIGN(0x10);
+        __text_end = .;
+        . = ALIGN(0x10);
+    } > e51_itim
+
+    .l2_scratchpad : ALIGN(0x10)
+    {
+        . = ALIGN (0x10);
+        __l2_scratchpad_load = LOADADDR(.l2_scratchpad);
+        __l2_scratchpad_start = .;
+        __l2_scratchpad_vma_start = .;
+        *(.l2_scratchpad)
+        . = ALIGN(0x10);
+        __l2_scratchpad_end = .;
+        __l2_scratchpad_vma_end = .;
+    } >scratchpad AT> e51_itim
+
+    /* short/global data section */
+    .sdata : ALIGN(0x10)
+    {
+        __sdata_load = LOADADDR(.sdata);
+        __sdata_start = .;
+        /* offset used with gp(gloabl pointer) are +/- 12 bits, so set point to middle of expected sdata range */
+        /* If sdata more than 4K, linker used direct addressing. Perhaps we should add check/warning to linker script if sdata is > 4k */
+        __global_pointer$ = . + 0x800;
+        *(.sdata .sdata.* .gnu.linkonce.s.*)
+        . = ALIGN(0x10);
+        __sdata_end = .;
+    } > dtim AT>e51_itim
+
+    /* data section */
+    .data : ALIGN(0x10)
+    {
+        __data_load = LOADADDR(.data);
+        __data_start = .;
+        *(.got.plt) *(.got)
+        *(.shdata)
+        *(.data .data.* .gnu.linkonce.d.*)
+        . = ALIGN(0x10);
+        __data_end = .;
+    } > dtim AT>e51_itim
+
+    /* sbss section */
+    .sbss : ALIGN(0x10)
+    {
+        __sbss_start = .;
+        *(.sbss .sbss.* .gnu.linkonce.sb.*)
+        *(.scommon)
+        . = ALIGN(0x10);
+        __sbss_end = .;
+    } > dtim
+
+    /* sbss section */
+    .bss : ALIGN(0x10)
+    {
+        __bss_start = .;
+        *(.shbss)
+        *(.bss .bss.* .gnu.linkonce.b.*)
+        *(COMMON)
+        . = ALIGN(0x10);
+        __bss_end = .;
+    } > dtim
+
+    /* End of uninitialized data segment */
+    _end = .;
+
+    .heap : ALIGN(0x10)
+    {
+        __heap_start = .;
+        . += HEAP_SIZE;
+        __heap_end = .;
+        . = ALIGN(0x10);
+        _heap_end = __heap_end;
+    } > dtim
+
+    /* must be on 4k boundary- corresponds to page size */
+    .stack : ALIGN(0x1000)
+    {
+        __stack_bottom = .;
+
+        PROVIDE(__stack_bottom_h0$ = .);
+        PROVIDE(__app_stack_bottom_h0 = .);
+        . += STACK_SIZE_E51_APPLICATION;
+        PROVIDE(__app_stack_top_h0 = .);
+        PROVIDE(__stack_top_h0$ = .);
+
+    } > dtim
+
+    /*
+     * memory shared accross harts.
+     * The boot Hart Local Storage holds a pointer to this area for each hart if
+     * when enabled by setting MPFS_HAL_SHARED_MEM_ENABLED define in the
+     * mss_sw_config.h
+     */
+    .app_hart_common : /* ALIGN(0x1000) */
+    {
+        PROVIDE(__app_hart_common_start = .);
+        . += SIZE_OF_COMMON_HART_MEM;
+        PROVIDE(__app_hart_common_end = .);
+    } > dtim
+
+    /*
+     * These are unused it the bootloader program but need to be preset for
+     * compilation, as used in non-bootloader function.
+     */
+    .unused_non_bootloader : ALIGN(0x10)
+    {
+        PROVIDE(__uninit_bottom$ = .);
+        PROVIDE(__uninit_top_h$ = .);
+        PROVIDE(__app_stack_bottom = .);
+        PROVIDE(__app_stack_top = .);
+        PROVIDE(__uninit_top_h$ = .);
+    } > dtim
+
+    __dtim_trampoline_end = .;
+}

--- a/jtag_trampoline/jtag_trampoline_crt.S
+++ b/jtag_trampoline/jtag_trampoline_crt.S
@@ -1,0 +1,284 @@
+#include "config.h"
+#include <sbi/riscv_asm.h>
+#include <sbi/riscv_encoding.h>
+#include <sbi/sbi_platform.h>
+#include <sbi/sbi_scratch.h>
+#include <sbi/sbi_trap.h>
+
+
+	.section .entry, "ax", @progbits
+	.attribute unaligned_access, 0
+	.attribute stack_align, 16
+	.align	3
+	.globl	_start
+
+_start:
+	la	t0, .early_trap_handler
+	csrw	CSR_MTVEC, t0
+	li	ra, 0
+.reset_regs:
+	// flush the instruction cache
+	fence.i
+
+	// Reset all registers except ra, a0, a1 and a2
+	li	gp,	0
+	li	sp,	0
+	li	tp,	0
+	li	t0,	0
+	li	t1,	0
+	li	t2,	0
+	li	s0,	0
+	li	s1,	0
+	li	a3,	0
+	li	a4,	0
+	li	a5,	0
+	li	a6,	0
+	li	a7,	0
+	li	s2,	0
+	li	s3,	0
+	li	s4,	0
+	li	s5,	0
+	li	s6,	0
+	li	s7,	0
+	li	s8,	0
+	li	s9,	0
+	li	s10,	0
+	li	s11,	0
+	li	t3,	0
+	li	t4,	0
+	li	t5,	0
+	li	t6,	0
+	csrw	CSR_MSCRATCH, 0
+
+.configure:
+	li	a0, 0
+	la	s8, STACK_SIZE_PER_HART
+        csrr	a0, CSR_MHARTID
+
+        la	tp, __stack_bottom
+        add	tp, tp, 63
+        and	tp, tp, -64
+        li	a1, 1
+
+.setup_stack:
+	mul	a2, s8, a0
+	add	tp, tp, a2
+        la	sp, STACK_SIZE_PER_HART
+	add	sp, sp, tp
+
+.disable_and_clear_interrupts:
+	csrw	CSR_MIE, zero			// disable all interrupts
+	csrw	CSR_MIP, zero			// clear all interrupts
+
+.do_work:
+    call	.clear_dtim
+    call	.clear_l2lim
+	li	a0, 0
+	call    .flush_early_caching
+    call	config_l2_cache
+    call	.clear_l2scratchpad
+	call	init_memory
+    call    HSS_Setup_Clocks
+
+	call	mss_nwc_init
+
+	la	a0, g_mss_uart0_lo
+	li	a1, 115200
+#define MSS_UART_DATA_8_BITS     (0x03)
+#define MSS_UART_NO_PARITY       (0x00)
+#define MSS_UART_ONE_STOP_BIT    (0x00)
+	li	a2, MSS_UART_DATA_8_BITS | MSS_UART_NO_PARITY | MSS_UART_ONE_STOP_BIT
+
+	la	a0, g_mss_uart1_lo
+	call	MSS_UART_init
+
+	la	a0, g_mss_uart2_lo
+	call	MSS_UART_init
+
+	la	a0, g_mss_uart3_lo
+	call	MSS_UART_init
+
+	la	a0, g_mss_uart4_lo
+	call	MSS_UART_init
+
+	la	a0, g_mss_uart0_lo
+	call	MSS_UART_init
+
+	la	a1, jtag_message
+	call	MSS_UART_polled_tx_string
+
+    ebreak
+
+.done:
+    j .
+
+	.align	3
+.early_trap_handler:
+	j .early_trap_handler
+
+.clear_l2scratchpad:
+	// Clear the LIM
+	//
+	// On reset, the first 15 ways are L2 and the last way is cache
+	// We can initialize all, as cache write through to DDR is blocked
+	// until DDR is initialized, so will have no effect other than clear ECC
+	//
+	// NOTE: we need to check if we are debugging from LIM,if so do not initialize
+	la	a4, __l2_start
+	la	a5, __l2_end
+	j	1f
+.clear_l2lim:
+	// Clear the LIM
+	//
+	// On reset, the first 15 ways are L2 and the last way is cache
+	// We can initialize all, as cache write through to DDR is blocked
+	// until DDR is initialized, so will have no effect other than clear ECC
+	//
+	// NOTE: we need to check if we are debugging from LIM,if so do not initialize
+	//
+	la 	a4, __l2lim_start
+	la	a5, __l2lim_end
+        j	1f
+.clear_dtim:
+        //
+        // Clear the E51 DTIM to prevent any memory errors on initial access
+        // to the cache
+        //
+        la	a4, __dtim_trampoline_end
+        la	a5, __dtim_end
+1:
+        // common loop used by both .clear_l2lim and .clear_dtim
+	REG_S	x0, 0(a4)
+	add	a4, a4, __SIZEOF_POINTER__
+	blt	a4, a5, 1b
+.done_clear:
+	ret
+
+/***********************************************************************************
+ *
+ */
+	.equ	L2_ZERO_DEVICE_ADDR, 0x0A000000
+	.equ	L2_CCACHE_ADDR, 0x02010000
+	.equ	FLUSH64_OFFSET, 0x200
+
+	//
+	// We want to flush anything that may be inadvertently cached
+	// by the actions of G5C at startup...
+	//
+	// The cache block is 64-bytes wide, and there are 4 banks * 512 sets * 16 ways.
+	//
+	// From power on, only a single way is enabled as cache (the remaining
+	// 15 are LIM), but this function is parameterisable (number of ways is
+	// passed via a0)...
+	//
+
+	// First, load the cache with "known" addresses by walking up L2 scratch
+	// with a 64-byte stride. We need to read (4 banks * 512 sets) to fill
+	// a single way.
+	//
+.flush_early_caching:
+					// a0 = num_ways
+	slli	a0, a0, 17		// a0' = a0 * (4 * 512 * 64)
+	li	a5, L2_ZERO_DEVICE_ADDR
+	add	a0, a0, a5		// a0''  = a0' + (4 * 512 * 64 * a0)
+                        		//  = 0x0A000000 + (4 * 512 * 64 * num_ways)
+	beq	a0, a5, .early_exit
+
+.preload_cache_with_known_addrs:
+	ld	a3, 0(a5)
+	addi	a5, a5, 64
+	bne	a5, a0, .preload_cache_with_known_addrs
+
+	//
+	// Now that the cache is filled with known addresses, we can simply flush each
+	// known address to end up with an empty cache...
+	//
+	li	a5, L2_ZERO_DEVICE_ADDR
+	li	a3, L2_CCACHE_ADDR
+.flush_known_addrs_from_cache:
+	sd	a5, FLUSH64_OFFSET(a3)      // write address to 0x02010200 (FLUSH64)
+	addi	a5, a5, 64
+	bne	a5, a0, .flush_known_addrs_from_cache
+
+.early_exit:
+	ret
+
+/***********************************************************************************
+ *
+ * The following init_memory() symbol overrides the weak symbol in the HAL and does
+ * a safe copy of RW data and clears zero-init memory
+ *
+ */
+        // zero_section helper function:
+        //       a0 = exec_start_addr
+        //       a1 = exec_end_addr
+        //
+	.text
+	.type	.zero_section, @function
+.zero_section:
+	beq	a0, a1, .zero_section_done
+	sd	zero, (a0)
+	addi	a0, a0, 8
+	j	.zero_section
+.zero_section_done:
+	ret
+
+        // copy_section helper function:
+        //	a0 = load_addr
+        //	a1 = exec_start_addr
+        //	a2 = exec_end_addr
+	.globl	copy_section
+	.type	copy_section, @function
+copy_section:
+        beq     a1, a0, .copy_section_done // if load_addr == exec_start_addr, goto copy_section_done
+.check_if_copy_section_done:
+	beq	a1, a2, .copy_section_done // if offset != length, goto keep_copying
+.keep_copying:
+	ld	a3, 0(a0)                  // val = *load_addr
+	sd	a3, 0(a1)                  // *exec_start_addr = val;
+	addi	a0, a0, 8                  // load_addr = load_addr + 8
+	addi	a1, a1, 8                  // exec_start_addr = exec_start_addr + 8
+        j	.check_if_copy_section_done
+.copy_section_done:
+        ret
+
+        // init_memory function, used to initialize memory early before C code runs
+        //
+	.globl	init_memory
+	.type	init_memory, @function
+init_memory:
+	addi	sp,sp,-16
+	sd	ra,8(sp)
+        //
+        // Initialize R/W data
+        //  (sdata and data sections)
+        //
+        la	a0, __sdata_load
+        la	a1, __sdata_start
+        la	a2, __sdata_end
+	call	copy_section
+
+        la	a0, __data_load
+        la	a1, __data_start
+        la	a2, __data_end
+	call	copy_section
+
+        //
+        // Clear zero-init memory
+        //  (SBSS and BSS sections)
+        //
+        la	a0, __sbss_start
+        la	a1, __sbss_end
+	call	.zero_section
+
+        la	a0, __bss_start
+        la	a1, __bss_end
+
+	ld	ra,8(sp)
+	addi	sp,sp,16
+	tail	.zero_section
+
+       .section .data
+       .align 8
+jtag_message:
+       .ascii "Executed HSS JTAG trampoline\r\n\0"

--- a/jtag_trampoline/jtag_trampoline_funcs.c
+++ b/jtag_trampoline/jtag_trampoline_funcs.c
@@ -1,0 +1,51 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include "mpfs_hal/mss_hal.h"
+
+bool HSS_Setup_Clocks(void);
+
+bool HSS_Setup_Clocks(void)
+{
+    static const uint32_t hss_subblk_clock_Config = 0xFFFFFFFFu;
+    const uint32_t hss_soft_reset_Config = SYSREG->SOFT_RESET_CR &
+        ~(
+           SOFT_RESET_CR_SGMII_MASK   |
+           SOFT_RESET_CR_CFM_MASK     |
+           SOFT_RESET_CR_ATHENA_MASK  |
+           SOFT_RESET_CR_FIC3_MASK    |
+           SOFT_RESET_CR_FIC2_MASK    |
+           SOFT_RESET_CR_FIC1_MASK    |
+           SOFT_RESET_CR_FIC0_MASK    |
+           SOFT_RESET_CR_DDRC_MASK    |
+           SOFT_RESET_CR_GPIO2_MASK   |
+           SOFT_RESET_CR_GPIO1_MASK   |
+           SOFT_RESET_CR_GPIO0_MASK   |
+           SOFT_RESET_CR_QSPI_MASK    |
+           SOFT_RESET_CR_RTC_MASK     |
+           SOFT_RESET_CR_FPGA_MASK    |
+           SOFT_RESET_CR_USB_MASK     |
+           SOFT_RESET_CR_CAN1_MASK    |
+           SOFT_RESET_CR_CAN0_MASK    |
+           SOFT_RESET_CR_I2C1_MASK    |
+           SOFT_RESET_CR_I2C0_MASK    |
+           SOFT_RESET_CR_SPI1_MASK    |
+           SOFT_RESET_CR_SPI0_MASK    |
+           SOFT_RESET_CR_MMUART4_MASK |
+           SOFT_RESET_CR_MMUART3_MASK |
+           SOFT_RESET_CR_MMUART2_MASK |
+           SOFT_RESET_CR_MMUART1_MASK |
+           SOFT_RESET_CR_MMUART0_MASK |
+           SOFT_RESET_CR_TIMER_MASK   |
+           SOFT_RESET_CR_MMC_MASK     |
+           SOFT_RESET_CR_MAC1_MASK    |
+           SOFT_RESET_CR_MAC0_MASK    |
+           SOFT_RESET_CR_ENVM_MASK);
+
+    SYSREG->SOFT_RESET_CR = 0x3FFFFFFEu; // everything but ENVM
+    SYSREG->SOFT_RESET_CR = hss_soft_reset_Config;
+    SYSREG->SUBBLK_CLOCK_CR = hss_subblk_clock_Config;
+
+    SYSREG->FABRIC_RESET_CR = FABRIC_RESET_CR_ENABLE_MASK;
+
+    return true;
+}

--- a/jtag_trampoline/run-hss.cfg
+++ b/jtag_trampoline/run-hss.cfg
@@ -1,0 +1,20 @@
+if {![exists HSS_DIR]} {
+    error "HSS_DIR variable not set. Use set HSS_DIR <path to directory with hss-*.elf"
+}
+
+reset init
+
+puts "Running JTAG trampoline"
+load_image "$HSS_DIR/hss-jtag_trampoline.hex" 0x0 ihex
+resume 0x01800000
+wait_halt
+
+puts "L2 configured for HSS"
+
+set SCRATCHPAD_ADDR 0x0A000000
+
+puts "Loading HSS"
+load_image "$HSS_DIR/hss-l2scratch.bin" $SCRATCHPAD_ADDR bin
+
+puts "Starting HSS"
+resume $SCRATCHPAD_ADDR


### PR DESCRIPTION
This pull request adds ability to run HSS in bootmode 0 by loading it over JTAG. In order to do so small trampoline executable is built. Details of operation and usage in `jtag_trampoline/README.md`.

Tested on Icicle board with ARM-JTAG-TINY-OCD-H JTAG probe and upstream OpenOCD. 

My goal is to provide capabilties for loading and running u-boot over JTAG without need to swap SD cards or access eMMC. Loading HSS over JTAG is first step, JTAG boot source integrated into HSS is next on my TODO list