### PR TITLE
Update mss_watchdog.h

### DIFF
--- a/baremetal/drivers/mss/mss_watchdog/mss_watchdog.h
+++ b/baremetal/drivers/mss/mss_watchdog/mss_watchdog.h
@@ -218,8 +218,8 @@ Time calculation example:
    mvrp_val = 0x989680u
    timeout_val = 0x3e8u
 
-   A presaclar = 256 is used on the MSS AXI clock.
-   Considering AXI clock = 25Mhz
+   A prescaler = 256 is used on the MSS AHB/APB clock.
+   Considering AHB/APB clock = 25Mhz
 
    The MVRP interrupt will happen after
    (0xFFFFF0 - 0x989680) * ( 1/25MHz/256)


### PR DESCRIPTION
Fixing example timer calculation. It needs to use the AHB/APB clock frequency, not the AXI clock frequency. We experimentally confirmed this in a system where the two clocks were different frequencies.