### PR TITLE
hss-payload-generator: allow building for RISC-V

### DIFF
--- a/tools/hss-payload-generator/generate_payload.c
+++ b/tools/hss-payload-generator/generate_payload.c
@@ -75,10 +75,6 @@ static_assert(sizeof(void *)==8, "Fatal: this program requires a 64bit compiler"
 #include "hss_types.h"
 #include "generate_payload.h"
 
-#ifdef __riscv
-#	error 1
-#endif
-
 #if defined(__LP64__) || defined(_LP64)
 #	ifndef PRIx64
 #		define PRIx64 "lx"


### PR DESCRIPTION
There is no good reason why we should not build and package U-Boot on the
Polarfire Icicle board itself.

Linux distributions tend to build packages natively.

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>