### PR TITLE
mss_usb: fix usbd_msc_process_request_cb()

### DIFF
--- a/baremetal/drivers/mss/mss_usb/mss_usb_device_msd.c
+++ b/baremetal/drivers/mss/mss_usb/mss_usb_device_msd.c
@@ -589,8 +589,6 @@ usbd_msc_process_request_cb
                 }
 
             default:
-                length = 0u;
-
                 return USB_FAIL;
         }
     }


### PR DESCRIPTION
Setting length = NULL has no effect.
For an unsupported request type we should not set *length either.

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>