### PR TITLE
Re-register harts after downloading image to correctly pass ancillary data

### DIFF
--- a/services/boot/hss_boot_service.c
+++ b/services/boot/hss_boot_service.c
@@ -351,7 +351,7 @@ static void boot_init_handler(struct StateMachine * const pMyMachine)
 
 /////////////////
 
-static void boot_setup_pmp_onEntry(struct StateMachine * const pMyMachine)
+static void register_harts(struct StateMachine * const pMyMachine)
 {
     struct HSS_Boot_LocalData * const pInstanceData = pMyMachine->pInstanceData;
     enum HSSHartId const target = pInstanceData->target;
@@ -394,6 +394,12 @@ static void boot_setup_pmp_onEntry(struct StateMachine * const pMyMachine)
 		pBootImage->hart[target-1].flags & BOOT_FLAG_ALLOW_WARM_REBOOT);
         }
     }
+}
+
+static void boot_setup_pmp_onEntry(struct StateMachine * const pMyMachine)
+{
+    /* Initially register harts, so that IPIs work for remainder of boot */
+    register_harts(pMyMachine);
 }
 
 static void boot_setup_pmp_handler(struct StateMachine * const pMyMachine)
@@ -602,6 +608,8 @@ static void boot_download_chunks_handler(struct StateMachine * const pMyMachine)
 
 static void boot_download_chunks_onExit(struct StateMachine * const pMyMachine)
 {
+    /* Re-register harts now that we've fully parsed the boot image (ancillary data etc) */
+    register_harts(pMyMachine);
 }
 
 /////////////////


### PR DESCRIPTION
# Description

This PR includes an example fix for the issue described in #58. Specifically, the issue is that the passed ancillary data pointer gets overwritten in `scratch->next_arg1`. This happens because the boot hart is registered very early in the boot process, when the ancillary data has not been parsed yet. This registered boot hart is later used to initialize relevant OpenSBI domains, which will then also not contain this value. This fix ensures that hart's are re-registered after boot image downloading is complete. It seems that these registrations are necessary in early boot in order for IPIs to work, so the early registration is also left in place.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested this by checking whether `next_arg1` is now correctly set when transferring to U-boot, which it is!

**Test Configuration**:
* Reference design release: v2023.02
* Hardware: Polarfire SoC Icicle Kit
* HSS version: 2023.06
* Bare metal examples version: N/A
* Buildroot / Yocto release: 132d25d51d6b9d14ae59f949c769e0e1a53101c5

# Checklist:

- [X] I have reviewed my code
- [ ] I have made corresponding changes to the documentation: N/A
- [X] My changes generate no new warnings
- [X] I have tested that my fix is effective or that my feature works
- [ ] I have added a maintainers file for any new board support: N/A
