### PR TITLE
fix CONFIG_SERVICE_MMC_FABRIC_SD_EMMC_DEMUX_SELECT_PRESENT option

### DIFF
--- a/baremetal/polarfire-soc-bare-metal-library/src/platform/mpfs_hal/common/nwc/mss_io.c
+++ b/baremetal/polarfire-soc-bare-metal-library/src/platform/mpfs_hal/common/nwc/mss_io.c
@@ -550,7 +550,7 @@ uint8_t switch_mssio_config(MSS_IO_OPTIONS option)
  */
 __attribute__((weak)) uint8_t fabric_sd_emmc_demux_present(void)
 {
-    return (uint8_t) FABRIC_SD_EMMC_DEMUX_SELECT_PRESENT;
+    return (uint8_t) CONFIG_SERVICE_MMC_FABRIC_SD_EMMC_DEMUX_SELECT_PRESENT;
 }
 
 /**
@@ -559,7 +559,7 @@ __attribute__((weak)) uint8_t fabric_sd_emmc_demux_present(void)
  */
 __attribute__((weak)) uint32_t * fabric_sd_emmc_demux_address(void)
 {
-    return (uint32_t *)FABRIC_SD_EMMC_DEMUX_SELECT_ADDRESS;
+    return (uint32_t *)CONFIG_SERVICE_MMC_FABRIC_SD_EMMC_DEMUX_SELECT_ADDRESS;
 }
 
 /**

--- a/baremetal/polarfire-soc-bare-metal-library/src/platform/mpfs_hal/common/nwc/mss_io_config.h
+++ b/baremetal/polarfire-soc-bare-metal-library/src/platform/mpfs_hal/common/nwc/mss_io_config.h
@@ -22,6 +22,8 @@
 extern "C" {
 #endif
 
+#include "config.h"
+
 #define CMD_SD_EMMC_DEMUX_EMMC_ON   0U
 #define CMD_SD_EMMC_DEMUX_SD_ON     1U
 
@@ -36,12 +38,12 @@ extern "C" {
  * Please note in Icicle kit reference design pre 2022.09, the address below
  * was 0x4F000000UL
  */
-#ifndef FABRIC_SD_EMMC_DEMUX_SELECT_ADDRESS
-#define FABRIC_SD_EMMC_DEMUX_SELECT_ADDRESS 0x4FFFFF00UL /*!< This is design
+#ifndef CONFIG_SERVICE_MMC_FABRIC_SD_EMMC_DEMUX_SELECT_ADDRESS
+#define CONFIG_SERVICE_MMC_FABRIC_SD_EMMC_DEMUX_SELECT_ADDRESS 0x4FFFFF00UL /*!< This is design
                                                             dependent */
 #endif
-#ifndef FABRIC_SD_EMMC_DEMUX_SELECT_PRESENT
-#define FABRIC_SD_EMMC_DEMUX_SELECT_PRESENT true /*!< true/false This is design
+#ifndef CONFIG_SERVICE_MMC_FABRIC_SD_EMMC_DEMUX_SELECT_PRESENT
+#define CONFIG_SERVICE_MMC_FABRIC_SD_EMMC_DEMUX_SELECT_PRESENT false /*!< true/false This is design
                                                       dependent */
 #endif
 


### PR DESCRIPTION
# Description

CONFIG_SERVICE_MMC_FABRIC_SD_EMMC_DEMUX_SELECT_PRESENT had no function, since a (similarly named) define was used instead.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Build with CONFIG_SERVICE_MMC_FABRIC_SD_EMMC_DEMUX_SELECT_PRESENT=y -> SD/eMMC Muxing is used
- [ ] Build with CONFIG_SERVICE_MMC_FABRIC_SD_EMMC_DEMUX_SELECT_PRESENT=n -> SD/eMMC Muxing is not used

**Test Configuration**:
* Reference design release: v2023.06
* Hardware: mpfs-icicle-kit-es
* HSS version: v2023.06
* Bare metal examples version: -
* Buildroot / Yocto release: -

# Checklist:

- [x] I have reviewed my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
- [ ] I have added a maintainers file for any new board support
