### PR TITLE
Fix watchdog timout on ymodem receiving and QSPI writing

### DIFF
--- a/baremetal/drivers/micron_mt25q/micron_mt25q.c
+++ b/baremetal/drivers/micron_mt25q/micron_mt25q.c
@@ -17,6 +17,11 @@
  */
 #include "drivers/micron_mt25q/micron_mt25q.h"
 #include "drivers/mss/mss_mmuart/mss_uart.h"
+#include "config.h"
+#include "hss_types.h"
+#if IS_ENABLED(CONFIG_SERVICE_WDOG)
+#  include "wdog_service.h"
+#endif
 
 
 /*Following constant must be defined if you want to use the interrupt mode
@@ -348,6 +353,9 @@ Flash_program
     uint8_t status = 0xFF;
     while(remaining_length > 0)
     {
+#if IS_ENABLED(CONFIG_SERVICE_WDOG)
+        HSS_Wdog_E51_Tickle();
+#endif
         uint32_t page_length;
 
         if(remaining_length >= PAGE_LENGTH)

--- a/services/qspi/qspi_api.c
+++ b/services/qspi/qspi_api.c
@@ -144,7 +144,8 @@ __attribute__((pure)) static inline uint32_t logical_to_physical_address_(const 
 
     const uint16_t logical_block_num = logical_addr / blockSize;
     const uint32_t remainder = logical_addr % blockSize;
-    uint16_t physical_block_number = pLogicalToPhysicalMap[logical_block_num];
+    //uint16_t physical_block_number = pLogicalToPhysicalMap[logical_block_num];
+    uint16_t physical_block_number = 0;
     uint32_t result = (physical_block_number * blockSize) + remainder;
 
     if (physical_block_number > blockCount) {

--- a/services/ymodem/ymodem_protocol.c
+++ b/services/ymodem/ymodem_protocol.c
@@ -201,6 +201,11 @@ static bool XYMODEM_ReadPacket(struct XYModem_Packet *pPacket, struct XYModem_St
         // Attempt to synchronize up to HSS_XYMODEM_MAX_SYNC_ATTEMPTS times
         //
         while (!synced && (syncAttempt < HSS_XYMODEM_MAX_SYNC_ATTEMPTS)) {
+
+#if IS_ENABLED(CONFIG_SERVICE_WDOG)
+            HSS_Wdog_E51_Tickle();
+#endif
+
             int16_t rawStartByte = getchar_with_timeout_(timeout_sec);
 
             if ((rawStartByte >= 0) && (rawStartByte < 256)) {


### PR DESCRIPTION
# Description

The watchdog does not get pet during the time that a file transfer over serial is taking place. This means if the file takes longer than ~25 seconds to transfer, the watchdog will reset the chip mid file transfer.

Also, when writing to QSPI, there is corruption in the logical to physical block mapping:

![image](https://github.com/user-attachments/assets/aeb7d486-c676-425c-a6e2-867e0974e79b)

The motivation for fixing this is because although there is "recovery code" by reconstructing the `pLogicalToPhysicalMap` array a second time when the corruption is detected, the first word was already thrown out when trying to write to QSPI the first time. The first word is important in an HSS payload because that contains the "magic" word (32 bits) that HSS will use to verify it is a valid image before trying to boot into it. If this "magic" word is not detected, then HSS will ignore the image and default to the next boot media it can find a valid image in.

You can see more information on both of these issues in issue ticket #82

## Type of change

`HSS_Wdog_E51_Tickle()` is used to reset the watchdog timer to prevent the watchdog from tripping. This needs to be called within the function responsible for performing YMODEM file transfers to prevent larger file transfers from expiring the watchdog timer. Likewise, these larger binary files can sometimes take longer than the default watchdog timeout when writing to QSPI, so the tickle function needs to be added there as well.

For the corruption in the logical to physical block mapping, I simply hard-coded the `physical_block_number` to 0. I hard-coded `physical_block_number` to 0 because it seems like the logical to physical mapping is just 1:1 and this function (`logical_to_physical_address_`) seems to only be called once for establishing the initial write or read location in QSPI. For example, after printing the `pLogicalToPhysicalMap[logical_block_num]` array when it is first constructed, the `logical_block_num` always corresponded with the value of `pLogicalToPhysicalMap[logical_block_num]`:

```
logical_block_num = 0; pLogicalToPhysicalMap[logical_block_num] = 0
logical_block_num = 1; pLogicalToPhysicalMap[logical_block_num] = 1
logical_block_num = 2; pLogicalToPhysicalMap[logical_block_num] = 2
.
.
.
```

However, later on when it comes time to write out to QSPI and `logical_block_num` is 0, the `pLogicalToPhysicalMap[logical_block_num]` size is way bigger than it should be given the block size of the Micron chip (should be less than or equal to 512 and it was 49374).

Therefore, just hard-coding the value to 0 fixes both the `HSS_QSPI_WriteBlock` and `HSS_QSPI_ReadBlock` functions since for most applications you only care about reading/writing starting at the first physical block of QSPI.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

To replicate this issue:
- Enable YMODEM and QSPI from menuconfig while building HSS (QSPI being utilized is Micron chip).
- Transfer a file that takes long enough for the watchdog timer to trip (~25 seconds).

To test this change fixes the issue, I transferred the full OS image "core-image-minimal-mtdutils-icicle-kit-es-nor.nor.mtdimg" generated from the Yocto build over YMODEM and flashed QSPI with it. 

Minicom YMODEM transfer:
![image](https://github.com/user-attachments/assets/810415bc-8c8e-4998-bf6b-be2d22da8196)

![image](https://github.com/user-attachments/assets/289d7c9c-a9d3-4774-9552-9f474c62dea3)

OS Image booting out of QSPI:
![image](https://github.com/user-attachments/assets/596ebad6-9cd7-4471-927a-2c67e7f56d12)

QSPI info from inside linux shell:
![image](https://github.com/user-attachments/assets/e2c68dd2-3d17-45c7-ac7c-dccd93df5160)


**Test Configuration**:
* Reference design release: https://github.com/polarfire-soc/icicle-kit-reference-design
* Hardware: ICICLE Kit
* HSS version: https://github.com/polarfire-soc/hart-software-services/tree/v2024.09
* Bare metal examples version:
* Buildroot / Yocto release: https://github.com/polarfire-soc/meta-polarfire-soc-yocto-bsp/tree/2024.09

# Checklist:

- [x] I have reviewed my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
- [ ] I have added a maintainers file for any new board support
