### PR TITLE
Guard against parallelism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,9 @@ else
   ifndef BOARD
     BOARD:=mpfs-icicle-kit-es
     export BOARD
-    $(info INFO: BOARD not specified, defaulting to ${BOARD}) # default to icicle if nothing found
+    ifeq ($(MAKE_RESTARTS),)
+      $(info INFO: BOARD not specified, defaulting to ${BOARD}) # default to icicle if nothing found
+    endif
     include boards/${BOARD}/Makefile
   else
     $(error Board >>${BOARD}<< not found)

--- a/application/os.mk
+++ b/application/os.mk
@@ -12,7 +12,9 @@ ifeq ($(OS), Windows_NT)
   #If we need to patch up path for Windows, we could do it here...
   #TOOLPATH:=${SC_INSTALL_DIR}riscv-unknown-elf-gcc\bin
   #export PATH:="$(TOOLPATH);$(PATH)"
-  $(info INFO: Windows detected)
+  ifeq ($(MAKE_RESTARTS),)
+    $(info INFO: Windows detected)
+  endif
   HOST_WINDOWS:=true
   PYTHON?=python.exe
   MPFS_BOOTMODE_PROGRAMMER = $(SC_INSTALL_DIR)\eclipse\jre\bin\java.exe -jar $(SC_INSTALL_DIR)\extras\mpfs\mpfsBootmodeProgrammer.jar
@@ -23,13 +25,17 @@ else
   ifneq (, $(findstring Linux, $(SYSTEM)))         # Linux-specific mods
     # Workaround SoftConsole v2021.1 Linux Python limitations by using system python
     export PATH:=/usr/bin:$(PATH)
-    $(info INFO: Linux detected)
+    ifeq ($(MAKE_RESTARTS),)
+      $(info INFO: Linux detected)
+    endif
     HOST_LINUX:=true
     PYTHON?=python3
     MPFS_BOOTMODE_PROGRAMMER = $(SC_INSTALL_DIR)/eclipse/jre/bin/java -jar $(SC_INSTALL_DIR)/extras/mpfs/mpfsBootmodeProgrammer.jar
     ifneq ($(origin XDG_SESSION_DESKTOP),undefined)
       HOST_LINUX_DESKTOP:=true
-      $(info INFO: Linux Desktop detected)
+      ifeq ($(MAKE_RESTARTS),)
+        $(info INFO: Linux Desktop detected)
+      endif
     endif
     #
     # We could detect if running in SoftConsole on Linux, but we don't need to

--- a/application/rules.mk
+++ b/application/rules.mk
@@ -109,11 +109,15 @@ endif
 # Stack protection is really useful, but if it is enabled, for now disabling LTO optimisation
 #
 ifdef CONFIG_CC_STACKPROTECTOR_STRONG
-  $(info INFO: Not enabling -flto as stack protector enabled)
+  ifeq ($(MAKE_RESTARTS),)
+    $(info INFO: Not enabling -flto as stack protector enabled)
+  endif
   CORE_CFLAGS+=-fstack-protector-strong
   # CORE_CFLAGS+=-fstack-clash-protection  # currently does nothing on RISC-V
 else
-  $(info INFO: NOTICE: enabling -flto (which means stack protection is disabled))
+  ifeq ($(MAKE_RESTARTS),)
+    $(info INFO: NOTICE: enabling -flto (which means stack protection is disabled))
+  endif
   OPT-y+=-flto=auto -ffat-lto-objects -fno-stack-protector
   OPT-y+=-fwhole-program -Wno-lto-type-mismatch
 endif
@@ -132,13 +136,17 @@ ifeq ($(HOST_LINUX), true)
   CC_VERSION = $(strip $(shell $(CC) -dumpversion))
   EXPECTED_CC_VERSION := 8.3.0
   ifneq ($(CC_VERSION),$(EXPECTED_CC_VERSION))
-    $(info INFO: Expected $(CC) version $(EXPECTED_CC_VERSION) but found $(CC_VERSION))
+    ifeq ($(MAKE_RESTARTS),)
+      $(info INFO: Expected $(CC) version $(EXPECTED_CC_VERSION) but found $(CC_VERSION))
+    endif
   endif
 
   CC_MACHINE = $(strip $(shell $(CC) -dumpmachine))
   EXPECTED_CC_MACHINE := riscv64-unknown-elf
   ifneq ($(CC_MACHINE),$(EXPECTED_CC_MACHINE))
-    $(info INFO: Expected $(CC) version $(EXPECTED_CC_MACHINE) but found $(CC_MACHINE))
+    ifeq ($(MAKE_RESTARTS),)
+      $(info INFO: Expected $(CC) version $(EXPECTED_CC_MACHINE) but found $(CC_MACHINE))
+    endif
   endif
 endif
 

--- a/boards/aries-m100pfsevp/Makefile
+++ b/boards/aries-m100pfsevp/Makefile
@@ -30,7 +30,9 @@
 #
 # The ARIES Embedded module M100PFS on the board M100PFSEVP
 #
-$(info aries-m100pfsevp selected)
+ifeq ($(MAKE_RESTARTS),)
+  $(info aries-m100pfsevp selected)
+endif
 
 TARGET-l2scratch=hss-l2scratch.elf
 TARGET-envm-wrapper=hss-envm-wrapper.elf
@@ -146,7 +148,7 @@ endif
 endif
 
 config.h: $(SOC_CONFIG_FILES)
-$(SOC_CONFIG_FILES): $(SOC_FPGA_DESIGN_XML_FILE)
+$(SOC_CONFIG_FILES) &: $(SOC_FPGA_DESIGN_XML_FILE)
 	@mkdir -p $(BINDIR)/$(BOARD_DIR)
 	@$(ECHO) " MPFSCFGGEN    $<";
 	$(PYTHON) tools/polarfire-soc-configuration-generator/mpfs_configuration_generator.py $< $(BINDIR)/$(BOARD_DIR)

--- a/boards/custom-board-design/Makefile
+++ b/boards/custom-board-design/Makefile
@@ -27,7 +27,9 @@
 # Defines target-specific build-rules variables, extra sources and include paths
 #
 
-$(info custom-board-design selected)
+ifeq ($(MAKE_RESTARTS),)
+  $(info custom-board-design selected)
+endif
 
 TARGET-l2scratch=hss-l2scratch.elf
 TARGET-envm-wrapper=hss-envm-wrapper.elf
@@ -147,7 +149,7 @@ endif
 endif
 
 config.h: $(SOC_CONFIG_FILES)
-$(SOC_CONFIG_FILES): $(SOC_FPGA_DESIGN_XML_FILE)
+$(SOC_CONFIG_FILES) &: $(SOC_FPGA_DESIGN_XML_FILE)
 	@mkdir -p $(BINDIR)/$(BOARD_DIR)
 	@$(ECHO) " MPFSCFGGEN    $<";
 	$(PYTHON) tools/polarfire-soc-configuration-generator/mpfs_configuration_generator.py $< $(BINDIR)/$(BOARD_DIR)

--- a/boards/mpfs-beaglev-fire/Makefile
+++ b/boards/mpfs-beaglev-fire/Makefile
@@ -30,7 +30,9 @@
 #
 # BeagleV-Fire
 #
-$(info mpfs-beaglev-fire selected)
+ifeq ($(MAKE_RESTARTS),)
+  $(info mpfs-beaglev-fire selected)
+endif
 
 PACKAGE=FCVG484
 DIE=MPFS025T
@@ -157,7 +159,7 @@ endif
 endif
 
 config.h: $(SOC_CONFIG_FILES)
-$(SOC_CONFIG_FILES): $(SOC_FPGA_DESIGN_XML_FILE)
+$(SOC_CONFIG_FILES) &: $(SOC_FPGA_DESIGN_XML_FILE)
 	@mkdir -p $(BINDIR)/$(BOARD_DIR)
 	@$(ECHO) " MPFSCFGGEN    $<";
 	$(PYTHON) tools/polarfire-soc-configuration-generator/mpfs_configuration_generator.py $< $(BINDIR)/$(BOARD_DIR)

--- a/boards/mpfs-disco-kit/Makefile
+++ b/boards/mpfs-disco-kit/Makefile
@@ -27,7 +27,9 @@
 # Defines target-specific build-rules variables, extra sources and include paths
 #
 
-$(info mpfs-disco-kit selected)
+ifeq ($(MAKE_RESTARTS),)
+  $(info mpfs-disco-kit selected)
+endif
 
 TARGET-l2scratch=hss-l2scratch.elf
 TARGET-envm-wrapper=hss-envm-wrapper.elf
@@ -152,7 +154,7 @@ endif
 endif
 
 config.h: $(SOC_CONFIG_FILES)
-$(SOC_CONFIG_FILES): $(SOC_FPGA_DESIGN_XML_FILE)
+$(SOC_CONFIG_FILES) &: $(SOC_FPGA_DESIGN_XML_FILE)
 	@mkdir -p $(BINDIR)/$(BOARD_DIR)
 	@$(ECHO) " MPFSCFGGEN    $<";
 	$(PYTHON) tools/polarfire-soc-configuration-generator/mpfs_configuration_generator.py $< $(BINDIR)/$(BOARD_DIR)

--- a/boards/mpfs-icicle-kit-es/Makefile
+++ b/boards/mpfs-icicle-kit-es/Makefile
@@ -27,7 +27,9 @@
 # Defines target-specific build-rules variables, extra sources and include paths
 #
 
-$(info mpfs-icicle-kit-es selected)
+ifeq ($(MAKE_RESTARTS),)
+  $(info mpfs-icicle-kit-es selected)
+endif
 
 TARGET-l2scratch=hss-l2scratch.elf
 TARGET-envm-wrapper=hss-envm-wrapper.elf
@@ -156,7 +158,7 @@ endif
 endif
 
 config.h: $(SOC_CONFIG_FILES)
-$(SOC_CONFIG_FILES): $(SOC_FPGA_DESIGN_XML_FILE)
+$(SOC_CONFIG_FILES) &: $(SOC_FPGA_DESIGN_XML_FILE)
 	@mkdir -p $(BINDIR)/$(BOARD_DIR)
 	@$(ECHO) " MPFSCFGGEN    $<";
 	$(PYTHON) tools/polarfire-soc-configuration-generator/mpfs_configuration_generator.py $< $(BINDIR)/$(BOARD_DIR)

--- a/boards/mpfs-icicle-kit/Makefile
+++ b/boards/mpfs-icicle-kit/Makefile
@@ -27,7 +27,9 @@
 # Defines target-specific build-rules variables, extra sources and include paths
 #
 
-$(info mpfs-icicle-kit selected)
+ifeq ($(MAKE_RESTARTS),)
+  $(info mpfs-icicle-kit selected)
+endif
 
 TARGET-l2scratch=hss-l2scratch.elf
 TARGET-envm-wrapper=hss-envm-wrapper.elf
@@ -156,7 +158,7 @@ endif
 endif
 
 config.h: $(SOC_CONFIG_FILES)
-$(SOC_CONFIG_FILES): $(SOC_FPGA_DESIGN_XML_FILE)
+$(SOC_CONFIG_FILES) &: $(SOC_FPGA_DESIGN_XML_FILE)
 	@mkdir -p $(BINDIR)/$(BOARD_DIR)
 	@$(ECHO) " MPFSCFGGEN    $<";
 	$(PYTHON) tools/polarfire-soc-configuration-generator/mpfs_configuration_generator.py $< $(BINDIR)/$(BOARD_DIR)

--- a/boards/mpfs-video-kit/Makefile
+++ b/boards/mpfs-video-kit/Makefile
@@ -27,7 +27,9 @@
 # Defines target-specific build-rules variables, extra sources and include paths
 #
 
-$(info mpfs-video-kit selected)
+ifeq ($(MAKE_RESTARTS),)
+  $(info mpfs-video-kit selected)
+endif
 
 TARGET-l2scratch=hss-l2scratch.elf
 TARGET-envm-wrapper=hss-envm-wrapper.elf
@@ -135,7 +137,7 @@ endif
 endif
 
 config.h: $(SOC_CONFIG_FILES)
-$(SOC_CONFIG_FILES): $(SOC_FPGA_DESIGN_XML_FILE)
+$(SOC_CONFIG_FILES) &: $(SOC_FPGA_DESIGN_XML_FILE)
 	@mkdir -p $(BINDIR)/$(BOARD_DIR)
 	@$(ECHO) " MPFSCFGGEN    $<";
 	$(PYTHON) tools/polarfire-soc-configuration-generator/mpfs_configuration_generator.py $< $(BINDIR)/$(BOARD_DIR)

--- a/boards/polarberry/Makefile
+++ b/boards/polarberry/Makefile
@@ -27,7 +27,9 @@
 # Defines target-specific build-rules variables, extra sources and include paths
 #
 
-$(info polarberry selected)
+ifeq ($(MAKE_RESTARTS),)
+  $(info polarberry selected)
+endif
 
 
 TARGET-l2scratch=hss-l2scratch.elf
@@ -152,7 +154,7 @@ endif
 endif
 
 config.h: $(SOC_CONFIG_FILES)
-$(SOC_CONFIG_FILES): $(SOC_FPGA_DESIGN_XML_FILE)
+$(SOC_CONFIG_FILES) &: $(SOC_FPGA_DESIGN_XML_FILE)
 	@mkdir -p $(BINDIR)/$(BOARD_DIR)
 	@$(ECHO) " MPFSCFGGEN    $<";
 	$(PYTHON) tools/polarfire-soc-configuration-generator/mpfs_configuration_generator.py $< $(BINDIR)/$(BOARD_DIR)

--- a/envm-wrapper/Makefile
+++ b/envm-wrapper/Makefile
@@ -80,8 +80,10 @@ endef
 MPFS_BOOTMODE_PROGRAMMER_VERSION := $(findstring v3.6,$(shell $(MPFS_BOOTMODE_PROGRAMMER) --help))
 EXPECTED_MPFS_BOOTMODE_PROGRAMMER_VERSION := v3.6
 ifneq ($(MPFS_BOOTMODE_PROGRAMMER_VERSION),$(EXPECTED_MPFS_BOOTMODE_PROGRAMMER_VERSION))
-  $(info INFO: Expected mpfsBootmodeProgrammer.jar version $(EXPECTED_MPFS_BOOTMODE_PROGRAMMER_VERSION) but found $(MPFS_BOOTMODE_PROGRAMMER_VERSION))
-  $(info INFO: This version of the HSS relies on SoftConsole v2021.3 or later)
+  ifeq ($(MAKE_RESTARTS),)
+    $(info INFO: Expected mpfsBootmodeProgrammer.jar version $(EXPECTED_MPFS_BOOTMODE_PROGRAMMER_VERSION) but found $(MPFS_BOOTMODE_PROGRAMMER_VERSION))
+    $(info INFO: This version of the HSS relies on SoftConsole v2021.3 or later)
+  endif
 endif
 
 $(TARGET-envm-wrapper): LIBS:=

--- a/envm-wrapper/Makefile
+++ b/envm-wrapper/Makefile
@@ -77,7 +77,7 @@ define common-boot-mode-programmer
 endef
 
 
-MPFS_BOOTMODE_PROGRAMMER_VERSION := $(findstring v3.6,$(shell $(MPFS_BOOTMODE_PROGRAMMER) --help))
+MPFS_BOOTMODE_PROGRAMMER_VERSION := $(shell $(MPFS_BOOTMODE_PROGRAMMER) --help 2>/dev/null | awk '/mpfsBootmodeProgrammer/{for(i=1;i<=NF;i++){if($$i ~ /^v[0-9]+\.[0-9]+$$/) print $$i}}')
 EXPECTED_MPFS_BOOTMODE_PROGRAMMER_VERSION := v3.6
 ifneq ($(MPFS_BOOTMODE_PROGRAMMER_VERSION),$(EXPECTED_MPFS_BOOTMODE_PROGRAMMER_VERSION))
   ifeq ($(MAKE_RESTARTS),)


### PR DESCRIPTION
# Description

When `make` is run with `-j<n>` the `MPFSCFGGEN` step goes a little haywire.
@burkeb543 and I have been tinkering with speeding up the build and this is what we came across.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

All board variants have been tested with:
`make -j4 BOARD=<variant>`.

# Checklist:

- [x] I have reviewed my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
- [ ] I have added a maintainers file for any new board support
