### PR TITLE
Support for HSS with sNVM flash/boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ include/tool_versions.h
 services/opensbi/opensbi_ecall_exts.c
 compile_commands.json
 .cache/
+build/

--- a/SNVM_BOOT_GUIDE.md
+++ b/SNVM_BOOT_GUIDE.md
@@ -1,0 +1,378 @@
+# PolarFire SoC sNVM Boot Guide
+
+## Overview
+
+This guide describes the HSS sNVM boot feature, which enables booting an HSS payload
+from the PolarFire SoC Secure NVM (sNVM) into L2-LIM without requiring DDR memory or
+an external flash device.
+
+The PolarFire SoC contains 221 pages of Secure NVM (sNVM), each holding 252 bytes in
+non-authenticated plaintext mode, for a total capacity of approximately **55 KB**
+(55,692 bytes). The sNVM is accessed through the System Controller via the
+`MSS_SYS_secure_nvm_read()` and `MSS_SYS_secure_nvm_write()` services.
+
+The sNVM boot feature adds a storage backend to the Hart Software Services (HSS) that
+reads an HSS-format payload from sNVM pages at boot time, assembles it into an L2-LIM
+staging area, and passes it to the standard HSS boot service. This enables a boot chain
+that uses only on-chip memory (eNVM + sNVM + L2-LIM) with no DDR or external flash
+dependency.
+
+### Boot Chain
+
+```
+eNVM (128 KB)          sNVM (55 KB)          L2-LIM (1.5 MB)
++-------------+        +------------+        +------------------+
+| HSS  (E51)  |  --->  |  Payload   |  --->  | Payload runs on  |
+| Boot Mode 1 |        |  (binary)  |        | U54 harts        |
++-------------+        +------------+        +------------------+
+```
+
+1. HSS boots from eNVM on the E51 monitor hart (Boot Mode 1)
+2. HSS reads the payload from sNVM pages and assembles it in the L2-LIM staging area
+3. HSS chunk-copies the payload to its target execution address in L2-LIM
+4. Payload runs on U54 hart(s) in S-mode (with OpenSBI services provided by HSS)
+
+### Memory Layout (No DDR)
+
+```
+L2-LIM (1.5 MB: 0x08000000 - 0x0817FFFF):
+  0x08000000 - 0x0803FFFF  HSS resident runtime (~256 KB)
+  0x08040000 - 0x0805FFFF  Payload code + data (128 KB target area)
+  0x08060000 - 0x080FFFFF  Application area (640 KB)
+  0x08100000 - 0x0810DFFF  sNVM staging buffer (~56 KB, temporary during boot)
+  0x08120000 - 0x0817FFFF  Stack (384 KB)
+
+sNVM (55 KB, 221 pages x 252 bytes):
+  Pages 0-220: HSS payload (hss-payload-generator output)
+
+eNVM (128 KB):
+  HSS firmware (Boot Mode 1)
+```
+
+## HSS Configuration
+
+### Kconfig Options
+
+The sNVM boot feature is controlled by the following Kconfig options under the
+**Boot Service** menu:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `CONFIG_SERVICE_BOOT_SNVM` | bool | n | Enable sNVM boot storage backend |
+| `CONFIG_SERVICE_BOOT_SNVM_START_PAGE` | int | 0 | First sNVM page index (0-220) |
+| `CONFIG_SERVICE_BOOT_SNVM_PAGE_COUNT` | int | 221 | Number of pages to read |
+| `CONFIG_SERVICE_BOOT_SNVM_STAGING_ADDR` | hex | 0x08100000 | L2-LIM address for page assembly |
+| `CONFIG_SERVICE_BOOT_SNVM_MAX_SIZE` | hex | 0xE000 | Maximum payload size (also used as the YMODEM receive buffer when DDR is disabled) |
+
+Additional recommended settings for no-DDR operation:
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `CONFIG_SKIP_DDR` | y | Skip DDR initialisation at boot |
+| `CONFIG_SERVICE_MMC` | n | Disable eMMC/SD (not needed) |
+| `CONFIG_SERVICE_YMODEM` | y | Enable YMODEM for sNVM programming |
+| `CONFIG_SERVICE_TINYCLI` | y | Enable the TinyCLI console |
+
+### Example def_config
+
+A reference configuration for the MPFS Video Kit with sNVM boot is provided at:
+
+```
+boards/mpfs-video-kit/def_config_snvm
+```
+
+Key settings in this configuration:
+
+- `CONFIG_SERVICE_BOOT_SNVM=y` with all sNVM sub-options
+- `CONFIG_SKIP_DDR=y` — no DDR initialisation
+- `CONFIG_SERVICE_YMODEM=y` — YMODEM console programming
+- `CONFIG_SERVICE_TINYCLI_TIMEOUT=5` — longer CLI timeout for development
+- `CONFIG_DEBUG_CHUNK_DOWNLOADS=y` — visible boot progress
+
+## Building HSS with sNVM Support
+
+```bash
+cd hart-software-services
+cp boards/mpfs-video-kit/def_config_snvm .config
+make clean && make BOARD=mpfs-video-kit \
+    CROSS_COMPILE=riscv64-unknown-elf- -j$(nproc)
+```
+
+Program the HSS binary to eNVM using SoftConsole, FPExpress, or the boot mode
+programmer:
+
+```bash
+java -jar $SC_INSTALL_DIR/extras/mpfs/mpfsBootmodeProgrammer.jar \
+    --bootmode 1 --die MPFS250T --package FCG1152 \
+    --workdir $PWD Default/hss-l2scratch.elf
+```
+
+## Generating an HSS Payload
+
+The payload must be in HSS payload format produced by `hss-payload-generator`.
+
+### Payload YAML Template
+
+```yaml
+set-name: 'PolarFire-SoC-HSS::MyPayload-L2LIM'
+hart-entry-points: {
+  u54_1: '0x08040000',
+  u54_2: '0x08040000',
+  u54_3: '0x08040000',
+  u54_4: '0x08040000'
+}
+payloads:
+  my_payload.elf: {
+    owner-hart: u54_1,
+    priv-mode: prv_s
+  }
+```
+
+- **href entry points** must match the payload's link address in L2-LIM
+- **owner-hart** specifies which U54 core executes the payload
+- **priv-mode** is typically `prv_s` (S-mode) when running under HSS/OpenSBI
+
+### Generate the Payload Binary
+
+```bash
+hss-payload-generator -vvv -c payload.yaml payload.bin
+ls -la payload.bin   # Must be <= 55,692 bytes (221 pages x 252 bytes)
+```
+
+If the payload exceeds sNVM capacity, reduce ELF size by:
+
+- Using `-Os` compiler optimisation
+- Stripping debug symbols: `riscv64-unknown-elf-strip --strip-debug payload.elf`
+- Disabling unused features
+- Using link-time optimisation (LTO)
+
+## Programming sNVM via YMODEM
+
+HSS provides runtime sNVM programming through the YMODEM utility. No external
+programmer is required.
+
+### Step-by-Step Programming
+
+1. Connect to the HSS UART0 console (115200 baud, 8N1).
+
+2. At the HSS TinyCLI prompt, enter the YMODEM utility:
+
+   ```
+   >> YMODEM
+   ```
+
+3. Select option **3** to start YMODEM receive:
+
+   ```
+    3. YMODEM Receive -- receive application file from host
+   ```
+
+4. Send the payload binary from the host:
+
+   **Using `sz` (lrzsz package):**
+   ```bash
+   sz --ymodem payload.bin < /dev/ttyUSB0 > /dev/ttyUSB0
+   ```
+
+   **Using minicom:** press `Ctrl+A` then `S`, select `ymodem`, navigate to `payload.bin`.
+
+   **Using picocom:** press `Ctrl+A` then `Ctrl+S`, type the path to `payload.bin`.
+
+5. After the transfer completes, select option **7** to write to sNVM:
+
+   ```
+    7. sNVM Write -- write received file to sNVM pages
+   ```
+
+   Progress is displayed as each page is written.
+
+6. Optionally verify with option **8**:
+
+   ```
+    8. sNVM Verify -- verify sNVM contents against received file
+   ```
+
+7. Select option **6** to exit, then issue the `SNVM` command to boot immediately
+   without a power cycle:
+
+   ```
+   >> SNVM
+   ```
+
+### Full Programming Session Example
+
+With `def_config_snvm` (MMC and QSPI disabled), the YMODEM utility menu appears as:
+
+```
+/sNVM Utility
+
+ 3. YMODEM Receive -- receive application file from host
+ 4. YMODEM Transmit -- send application file to host
+ 6. Quit -- quit Utility
+ 7. sNVM Write -- write received file to sNVM pages
+ 8. sNVM Verify -- verify sNVM contents against received file
+
+ Select a number:
+3
+Waiting for YMODEM transfer...
+[transfer payload.bin from host]
+Received 48576 bytes
+
+ Select a number:
+7
+Writing 48576 bytes to sNVM ...
+Writing 193 bytes to sNVM pages 0-192 ...
+  page 1/193
+  page 11/193
+  ...
+  page 191/193
+sNVM write complete: 193 pages written
+
+ Select a number:
+8
+Verifying 193 sNVM pages ...
+sNVM verify OK: 193 pages match
+
+ Select a number:
+6
+>> SNVM
+```
+
+## Verification
+
+After programming and rebooting, the HSS console should show:
+
+1. HSS banner with DDR training skipped (when `CONFIG_SKIP_DDR=y`)
+2. `sNVM: reading page X of Y...` — sNVM page assembly in progress
+3. `Boot Image registered...` — payload header validated
+4. Chunk download messages — payload copied to target L2-LIM address
+5. Payload output on its configured UART
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Resolution |
+|---------|-------------|------------|
+| `sNVM: bad magic` | sNVM contains invalid or uninitialised data | Re-program via YMODEM |
+| Payload too large | ELF exceeds 55,692 bytes | Strip symbols, apply `-Os`, use LTO |
+| No output after boot | Wrong entry point or link address | Verify YAML entry points match linker script |
+| `sNVM write page N failed` | System Controller error | Check page range (0-220), retry |
+| YMODEM timeout | Serial connection issue | Verify baud rate (115200), cable, and port |
+
+## sNVM Technical Reference
+
+| Property | Value |
+|----------|-------|
+| Page size (non-authenticated) | 252 bytes |
+| Page count | 221 (module indices 0-220) |
+| Total capacity | 55,692 bytes (~54.4 KB) |
+| Access method | System Controller services |
+| Read service | `MSS_SYS_secure_nvm_read()` |
+| Write service | `MSS_SYS_secure_nvm_write()` |
+| Write format | `MSS_SYS_SNVM_NON_AUTHEN_TEXT_REQUEST_CMD` |
+| Persistence | Non-volatile; survives power cycles |
+
+---
+
+## wolfBoot Integration
+
+[wolfBoot](https://github.com/wolfSSL/wolfBoot) is a secure bootloader that provides
+firmware authentication and update. When combined with the HSS sNVM boot feature,
+wolfBoot runs on a U54 hart in S-mode from L2-LIM and verifies/loads a signed
+application from external QSPI flash.
+
+### wolfBoot sNVM Boot Chain
+
+```
+eNVM            sNVM              L2-LIM              QSPI Flash
++------+       +----------+      +-----------+       +-------------+
+| HSS  | --->  | wolfBoot | ---> | wolfBoot  | --->  | Signed App  |
+| (E51)|       | payload  |      | verifies  |       | Image       |
++------+       +----------+      | & loads   |       +-------------+
+                                 | app       |
+                                 +-----------+
+```
+
+1. HSS (E51, eNVM) reads the wolfBoot HSS payload from sNVM
+2. wolfBoot (U54, L2-LIM) verifies the signed application in QSPI flash
+3. Application runs from L2-LIM after signature verification
+
+### wolfBoot Configuration
+
+The wolfBoot L2-LIM configuration and HSS payload YAML are maintained in the wolfBoot
+repository:
+
+- **Config**: `config/examples/polarfire_mpfs250_hss_l2lim.config`
+- **Payload YAML**: `hal/mpfs-l2lim.yaml`
+- **Linker script**: `hal/mpfs250-hss.ld`
+
+Key settings in `polarfire_mpfs250_hss_l2lim.config`:
+
+| Setting | Value | Description |
+|---------|-------|-------------|
+| `WOLFBOOT_ORIGIN` | 0x08040000 | wolfBoot load address in L2-LIM |
+| `WOLFBOOT_LOAD_ADDRESS` | 0x08060000 | Application load area in L2-LIM |
+| `WOLFBOOT_STACK_TOP` | 0x08180000 | Top of L2-LIM stack |
+| `WOLFBOOT_PARTITION_BOOT_ADDRESS` | 0x20020000 | QSPI flash boot partition |
+| `WOLFBOOT_PARTITION_UPDATE_ADDRESS` | 0x22000000 | QSPI flash update partition |
+| `WOLFBOOT_PARTITION_SWAP_ADDRESS` | 0x24000000 | QSPI flash swap partition |
+
+### Building wolfBoot for sNVM
+
+```bash
+cd wolfBoot
+cp config/examples/polarfire_mpfs250_hss_l2lim.config .config
+make clean && make wolfboot.elf
+```
+
+### Generating the wolfBoot HSS Payload
+
+```bash
+hss-payload-generator -vvv -c hal/mpfs-l2lim.yaml wolfboot.bin
+ls -la wolfboot.bin   # Verify <= 55,692 bytes
+```
+
+### Size Considerations
+
+wolfBoot must fit within sNVM capacity (~55 KB) including the HSS payload header
+overhead. Options to reduce binary size:
+
+- Crypto algorithm selection (ECC256 vs ECC384)
+- Math library selection (`SPMATHALL`, `NO_ASM`)
+- Compiler flags (`-Os`, LTO)
+- Disable unused features (delta updates, encrypted images)
+
+### Programming wolfBoot to sNVM
+
+Follow the YMODEM programming steps above, substituting `wolfboot.bin` as the payload.
+
+### Signing and Loading the Application
+
+After wolfBoot is running from sNVM/L2-LIM, sign and program the application to QSPI:
+
+```bash
+# Sign the application image
+./tools/keytools/sign --ecc384 --sha384 test-app/image.elf \
+    wolfboot_signing_private_key.der 1
+
+# Program to QSPI flash via UART
+python3 tools/scripts/mpfs_qspi_prog.py /dev/ttyUSB1 \
+    test-app/image_v1_signed.bin 0x20000
+```
+
+### Expected Boot Output
+
+On UART1 (U54):
+
+```
+wolfBoot HAL Init
+wolfBoot version: X.Y.Z
+Verifying image at 0x20020000...
+Signature OK (ECC384)
+Booting application at 0x08060000
+```
+
+## References
+
+- [PolarFire SoC documentation](https://github.com/polarfire-soc/polarfire-soc-documentation)
+- [wolfBoot](https://github.com/wolfSSL/wolfBoot)
+- PolarFire SoC MSS User's Guide — System Controller and sNVM services

--- a/boards/mpfs-video-kit/def_config_snvm
+++ b/boards/mpfs-video-kit/def_config_snvm
@@ -1,0 +1,201 @@
+
+#
+# Board/Design Configuration Options
+#
+
+#
+# mpfs-video-kit Configuration Options (sNVM + L2-LIM, No DDR)
+#
+CONFIG_SOC_FPGA_DESIGN_XML="boards/mpfs-video-kit/fpga_design/design_description/MSS_video-kit_mss_cfg.xml"
+# end of mpfs-video-kit Configuration Options
+# end of Board/Design Configuration Options
+
+#
+# Services
+#
+CONFIG_SERVICE_BEU=y
+CONFIG_SERVICE_BOOT=y
+
+#
+# Boot Service
+#
+# CONFIG_SERVICE_BOOT_USE_PAYLOAD is not set
+# CONFIG_SERVICE_BOOT_CUSTOM_FLOW is not set
+CONFIG_SERVICE_BOOT_DDR_TARGET_ADDR=0x08100000
+# CONFIG_SERVICE_BOOT_MMC_USE_GPT is not set
+
+# sNVM Boot: read wolfBoot HSS payload from sNVM pages into L2-LIM
+CONFIG_SERVICE_BOOT_SNVM=y
+CONFIG_SERVICE_BOOT_SNVM_START_PAGE=0
+CONFIG_SERVICE_BOOT_SNVM_PAGE_COUNT=221
+CONFIG_SERVICE_BOOT_SNVM_STAGING_ADDR=0x08100000
+CONFIG_SERVICE_BOOT_SNVM_MAX_SIZE=0xE000
+# end of Boot Service
+
+CONFIG_SERVICE_DDR=y
+CONFIG_SERVICE_GOTO=y
+# CONFIG_SERVICE_HEALTHMON is not set
+# CONFIG_SERVICE_GPIO_UI is not set
+CONFIG_SERVICE_IPI_POLL=y
+# CONFIG_SERVICE_LOCKDOWN is not set
+# CONFIG_SERVICE_MMC is not set
+
+CONFIG_SERVICE_OPENSBI=y
+CONFIG_SERVICE_OPENSBI_CRYPTO=y
+
+#
+# SBI Extension Support
+#
+CONFIG_SBI_ECALL_TIME=y
+CONFIG_SBI_ECALL_RFENCE=y
+CONFIG_SBI_ECALL_IPI=y
+CONFIG_SBI_ECALL_HSM=y
+CONFIG_SBI_ECALL_SRST=y
+CONFIG_SBI_ECALL_PMU=y
+CONFIG_SBI_ECALL_LEGACY=y
+CONFIG_SBI_ECALL_VENDOR=y
+# end of SBI Extension Support
+
+CONFIG_FDT_IPI=y
+CONFIG_FDT_IPI_MSWI=y
+CONFIG_FDT_IPI_PLICSW=y
+CONFIG_FDT_IRQCHIP=y
+CONFIG_FDT_IRQCHIP_PLIC=y
+CONFIG_FDT_RESET=y
+CONFIG_FDT_SERIAL=y
+CONFIG_FDT_SERIAL_UART8250=y
+CONFIG_FDT_TIMER=y
+CONFIG_FDT_TIMER_MTIMER=y
+# CONFIG_SERVICE_POWERMODE is not set
+# CONFIG_SERVICE_QSPI is not set
+CONFIG_SERVICE_REBOOT=y
+# CONFIG_SERVICE_SCRUB is not set
+CONFIG_SERVICE_SGDMA=y
+# CONFIG_SERVICE_SPI is not set
+CONFIG_SERVICE_TINYCLI=y
+
+#
+# Tiny Command Line Interface
+#
+CONFIG_SERVICE_TINYCLI_TIMEOUT=5
+# CONFIG_SERVICE_TINYCLI_MONITOR is not set
+# CONFIG_SERVICE_TINYCLI_ENABLE_PREBOOT_TIMEOUT is not set
+# end of Tiny Command Line Interface
+
+# CONFIG_SERVICE_UART is not set
+# CONFIG_SERVICE_USBDMSC is not set
+
+CONFIG_SERVICE_WDOG=y
+
+#
+# Watchdog Service
+#
+# CONFIG_SERVICE_WDOG_DEBUG is not set
+CONFIG_SERVICE_WDOG_DEBUG_TIMEOUT_SEC=240
+CONFIG_SERVICE_WDOG_ENABLE_E51=y
+# end of Watchdog Service
+
+CONFIG_SERVICE_YMODEM=y
+# end of Services
+
+#
+# General Configuration Options
+#
+
+#
+# Miscellaneous
+#
+# CONFIG_USE_PCIE is not set
+CONFIG_OPENSBI=y
+# CONFIG_USE_IHC is not set
+# CONFIG_USE_IHC_V2 is not set
+CONFIG_USE_USER_CRYPTO=y
+
+#
+# Serial Port
+#
+# CONFIG_UART_SURRENDER is not set
+CONFIG_UART_POST_BOOT=0
+# end of Serial Port
+
+#
+# Tamper
+#
+# CONFIG_USE_TAMPER is not set
+# end of Tamper
+
+CONFIG_ALLOW_COLDREBOOT=y
+
+#
+# Cold Reboot
+#
+CONFIG_ALLOW_COLDREBOOT_ALWAYS=y
+CONFIG_COLDREBOOT_TRY_AUTO_UPDATE=y
+# CONFIG_ALLOW_COLDREBOOT_ON_OPENSBI_FAULT is not set
+# end of Cold Reboot
+# end of Miscellaneous
+
+#
+# OpenSBI
+#
+# CONFIG_PROVIDE_DTB is not set
+# end of OpenSBI
+
+#
+# Memory Options
+#
+CONFIG_SKIP_DDR=y
+# CONFIG_MEMTEST is not set
+# CONFIG_USE_PDMA is not set
+# CONFIG_INITIALIZE_MEMORIES is not set
+# end of Memory Options
+# end of General Configuration Options
+
+#
+# Build Options
+#
+CONFIG_COLOR_OUTPUT=y
+CONFIG_USE_LOGO=y
+# CONFIG_CC_STACKPROTECTOR_STRONG is not set
+# CONFIG_CC_DUMP_STACKSIZE is not set
+# CONFIG_LD_RELAX is not set
+CONFIG_CC_USE_MAKEDEP=y
+CONFIG_CC_USE_GNU_BUILD_ID=y
+CONFIG_CC_HAS_INTTYPES=y
+CONFIG_DISPLAY_TOOL_VERSIONS=y
+# CONFIG_LOG_FUNCTION_NAMES is not set
+# end of Build Options
+
+#
+# Compression
+#
+# CONFIG_COMPRESSION is not set
+# end of Compression
+
+#
+# Crypto
+#
+# CONFIG_CRYPTO_SIGNING is not set
+# end of Crypto
+
+#
+# Debug Options
+#
+CONFIG_DEBUG_LOG_STATE_TRANSITIONS=y
+CONFIG_DEBUG_LOOP_TIMES=y
+CONFIG_DEBUG_LOOP_TIMES_THRESHOLD=2500000
+# CONFIG_DEBUG_IPI_STATS is not set
+CONFIG_DEBUG_CHUNK_DOWNLOADS=y
+# CONFIG_DEBUG_MSCGEN_IPI is not set
+# CONFIG_DEBUG_PROFILING_SUPPORT is not set
+CONFIG_DEBUG_PERF_CTRS=y
+CONFIG_DEBUG_PERF_CTRS_NUM=16
+# CONFIG_DEBUG_RESET_REASON is not set
+# end of Debug Options
+
+#
+# SSMB Options
+#
+CONFIG_IPI_MAX_NUM_QUEUE_MESSAGES=8
+# CONFIG_IPI_FIXED_BASE is not set
+# end of SSMB Options

--- a/boards/mpfs-video-kit/hss-l2scratch.ld
+++ b/boards/mpfs-video-kit/hss-l2scratch.ld
@@ -1,0 +1,162 @@
+OUTPUT_ARCH( "riscv" )
+ENTRY(_start)
+MEMORY
+{
+    envm (rx) : ORIGIN = 0x20220100, LENGTH = (128k-256)
+    dtim (rwx) : ORIGIN = 0x01000000, LENGTH = 7k
+    switch_code (rx) : ORIGIN = 0x01001c00, LENGTH = 1k
+    e51_itim (rwx) : ORIGIN = 0x01800000, LENGTH = 28k
+    u54_1_itim (rwx) : ORIGIN = 0x01808000, LENGTH = 28k
+    u54_2_itim (rwx) : ORIGIN = 0x01810000, LENGTH = 28k
+    u54_3_itim (rwx) : ORIGIN = 0x01818000, LENGTH = 28k
+    u54_4_itim (rwx) : ORIGIN = 0x01820000, LENGTH = 28k
+    l2lim (rwx) : ORIGIN = 0x08000000, LENGTH = 512k
+    l2zerodevice (rwx) : ORIGIN = 0x0A000000, LENGTH = 512k
+    ddr (rwx) : ORIGIN = 0x80000000, LENGTH = 32m
+    ddrhi (rwx) : ORIGIN = 0x1000000000, LENGTH = 1888m
+    ncddrhi (rwx) : ORIGIN = 0x1400000000, LENGTH = 2048m
+}
+PROVIDE(HEAP_SIZE = 0k);
+PROVIDE(STACK_SIZE_PER_HART = 16k);
+SECTIONS
+{
+    PROVIDE(__envm_start = ORIGIN(envm));
+    PROVIDE(__envm_end = ORIGIN(envm) + LENGTH(envm));
+    PROVIDE(__l2lim_start = ORIGIN(l2lim));
+    PROVIDE(__l2lim_end = ORIGIN(l2lim) + LENGTH(l2lim));
+    PROVIDE(__l2_start = ORIGIN(l2zerodevice));
+    PROVIDE(__l2_end = ORIGIN(l2zerodevice) + LENGTH(l2zerodevice));
+    PROVIDE(__ddr_start = ORIGIN(ddr));
+    PROVIDE(__ddr_end = ORIGIN(ddr) + LENGTH(ddr));
+    PROVIDE(__ddrhi_start = ORIGIN(ddrhi));
+    PROVIDE(__ddrhi_end = ORIGIN(ddrhi) + LENGTH(ddrhi));
+    PROVIDE(__ddrhi_max_end = ORIGIN(ddrhi) + LENGTH(ncddrhi));
+    PROVIDE(__ncddrhi_start = ORIGIN(ncddrhi));
+    PROVIDE(__ncddrhi_end = ORIGIN(ncddrhi) + LENGTH(ncddrhi));
+    PROVIDE(__dtim_start = ORIGIN(dtim));
+    PROVIDE(__dtim_end = ORIGIN(dtim) + LENGTH(dtim));
+    PROVIDE(__e51itim_start = ORIGIN(e51_itim));
+    PROVIDE(__e51itim_end = ORIGIN(e51_itim) + LENGTH(e51_itim));
+    PROVIDE(__u54_1_itim_start = ORIGIN(u54_1_itim));
+    PROVIDE(__u54_1_itim_end = ORIGIN(u54_1_itim) + LENGTH(u54_1_itim));
+    PROVIDE(__u54_2_itim_start = ORIGIN(u54_2_itim));
+    PROVIDE(__u54_2_itim_end = ORIGIN(u54_2_itim) + LENGTH(u54_2_itim));
+    PROVIDE(__u54_3_itim_start = ORIGIN(u54_3_itim));
+    PROVIDE(__u54_3_itim_end = ORIGIN(u54_3_itim) + LENGTH(u54_3_itim));
+    PROVIDE(__u54_4_itim_start = ORIGIN(u54_4_itim));
+    PROVIDE(__u54_4_itim_end = ORIGIN(u54_4_itim) + LENGTH(u54_4_itim));
+    . = __l2_start;
+    PROVIDE(_hss_start = .);
+    PROVIDE(__l2_scratchpad_vma_start = .);
+    .text : ALIGN(0x10)
+    {
+        *(.entry)
+        . = ALIGN(0x10);
+        *(.text .text.* .gnu.linkonce.t.*)
+        *(.plt)
+        . = ALIGN(0x10);
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*crtend.o(.ctors))
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*crtend.o(.dtors))
+        *(.rodata .rodata.* .gnu.linkonce.r.*)
+        *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2)
+        *(.srodata*)
+        *(.sdata2*)
+        *(.gcc_except_table)
+        *(.eh_frame_hdr)
+        *(.eh_frame)
+        KEEP (*(.init))
+        KEEP (*(.fini))
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP (*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array))
+        PROVIDE_HIDDEN (__init_array_end = .);
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP (*(.fini_array))
+        KEEP (*(SORT(.fini_array.*)))
+        PROVIDE_HIDDEN (__fini_array_end = .);
+        . = ALIGN(0x10);
+    } >l2zerodevice
+    .gnu_build_id : ALIGN(8) {
+        PROVIDE(gnu_build_id = .);
+        *(.note.gnu.build-id)
+    } >l2zerodevice
+    PROVIDE(_hss_end = .);
+    .ram_code : ALIGN(0x10)
+    {
+        __sc_load = LOADADDR (.ram_code);
+        __sc_start = .;
+        *(.ram_codetext)
+        *(.ram_codetext*)
+        *(.ram_coderodata)
+        *(.ram_coderodata*)
+        . = ALIGN (0x10);
+        __sc_end = .;
+    } >switch_code
+    .sdata : ALIGN(0x40)
+    {
+        __sdata_load = LOADADDR(.sdata);
+        __sdata_start = .;
+        __global_pointer$ = . + 0x800;
+        *(.sdata .sdata.* .gnu.linkonce.s.*)
+        . = ALIGN(0x10);
+        __sdata_end = .;
+    } >l2zerodevice
+    .data : ALIGN(0x40)
+    {
+        __data_load = LOADADDR(.data);
+        __data_start = .;
+        *(.got.plt) *(.got)
+        *(.shdata)
+        *(.data .data.* .gnu.linkonce.d.*)
+        . = ALIGN(0x10);
+        __data_end = .;
+    } >l2zerodevice
+    .sbss : ALIGN(0x40)
+    {
+        __sbss_start = .;
+        *(.sbss .sbss.* .gnu.linkonce.sb.*)
+        *(.scommon)
+        . = ALIGN(0x10);
+        __sbss_end = .;
+    } >l2zerodevice
+    .bss : ALIGN(0x40)
+    {
+        __bss_start = .;
+        *(.shbss)
+        *(.bss .bss.* .gnu.linkonce.b.*)
+        *(COMMON)
+        . = ALIGN(0x10);
+        __bss_end = .;
+    } >l2zerodevice
+    .stack : ALIGN(0x40)
+    {
+        __stack_bottom = .;
+        __stack_bottom_h0$ = .;
+        . += STACK_SIZE_PER_HART;
+        __stack_top_h0$ = . - 8;
+        __stack_bottom_h1$ = .;
+        . += STACK_SIZE_PER_HART;
+        __stack_top_h1$ = . - 8;
+        __stack_bottom_h2$ = .;
+        . += STACK_SIZE_PER_HART;
+        __stack_top_h2$ = . - 8;
+        __stack_bottom_h3$ = .;
+        . += STACK_SIZE_PER_HART;
+        __stack_top_h3$ = . - 8;
+        __stack_bottom_h4$ = .;
+        . += STACK_SIZE_PER_HART;
+        __stack_top_h4$ = . - 8;
+        __stack_top = .;
+    } >l2zerodevice
+    _end = .;
+    PROVIDE(__l2_scratchpad_vma_end = .);
+}

--- a/include/hss_boot_init.h
+++ b/include/hss_boot_init.h
@@ -42,6 +42,7 @@ void HSS_BootSelectEMMC(void);
 void HSS_BootSelectSDCARD(void);
 void HSS_BootSelectPayload(void);
 void HSS_BootSelectSPI(void);
+void HSS_BootSelectSNVM(void);
 
 void HSS_BootListStorageProviders(void);
 #ifdef __cplusplus

--- a/init/hss_boot_init.c
+++ b/init/hss_boot_init.c
@@ -23,8 +23,11 @@
 #include "hss_trigger.h"
 #include "u54_state.h"
 
-#if IS_ENABLED(CONFIG_SERVICE_SPI)
+#if IS_ENABLED(CONFIG_SERVICE_SPI) || IS_ENABLED(CONFIG_SERVICE_BOOT_SNVM)
 #  include <mss_sys_services.h>
+#endif
+
+#if IS_ENABLED(CONFIG_SERVICE_SPI)
 #  define SPI_FLASH_BOOT_ENABLED (CONFIG_SERVICE_BOOT_SPI_FLASH_OFFSET != 0xFFFFFFFF)
 #else
 #  define SPI_FLASH_BOOT_ENABLED 0
@@ -71,18 +74,20 @@
 // local module functions
 
 #if IS_ENABLED(CONFIG_SERVICE_BOOT)
+static void printBootImageDetails_(struct HSS_BootImage const * const pBootImage);
+static bool tryBootFunction_(struct HSS_Storage *pStorage, HSS_GetBootImageFnPtr_t getBootImageFunction);
+#if IS_ENABLED(CONFIG_SERVICE_MMC) || IS_ENABLED(CONFIG_SERVICE_QSPI) || IS_ENABLED(CONFIG_SERVICE_SPI)
 typedef bool (*HSS_BootImageCopyFnPtr_t)(void *pDest, size_t srcOffset, size_t byteCount);
 static bool copyBootImageToDDR_(struct HSS_BootImage *pBootImage, char *pDest,
     size_t srcOffset, HSS_BootImageCopyFnPtr_t pCopyFunction);
-
-static void printBootImageDetails_(struct HSS_BootImage const * const pBootImage);
-static bool tryBootFunction_(struct HSS_Storage *pStorage, HSS_GetBootImageFnPtr_t getBootImageFunction);
+#endif
 #endif
 
 static bool getBootImageFromQSPI_(struct HSS_Storage *pStorage, struct HSS_BootImage **ppBootImage);
 static bool getBootImageFromMMC_(struct HSS_Storage *pStorage, struct HSS_BootImage **ppBootImage);
 static bool getBootImageFromSpiFlash_(struct HSS_Storage *pStorage, struct HSS_BootImage **ppBootImage);
 static bool getBootImageFromPayload_(struct HSS_Storage *pStorage, struct HSS_BootImage **ppBootImage);
+static bool getBootImageFromSNVM_(struct HSS_Storage *pStorage, struct HSS_BootImage **ppBootImage);
 
 
 //
@@ -132,9 +137,23 @@ static struct HSS_Storage payloadStorage_ = {
     .flushWriteBuffer = NULL
 };
 #endif
+#if IS_ENABLED(CONFIG_SERVICE_BOOT_SNVM)
+static struct HSS_Storage snvmStorage_ = {
+    .name = "SNVM",
+    .getBootImage = getBootImageFromSNVM_,
+    .init = NULL,
+    .readBlock = NULL,
+    .writeBlock = NULL,
+    .getInfo = NULL,
+    .flushWriteBuffer = NULL
+};
+#endif
 
 static struct HSS_Storage *pStorages[] =
 {
+#if IS_ENABLED(CONFIG_SERVICE_BOOT_SNVM)
+	&snvmStorage_,
+#endif
 #if IS_ENABLED(CONFIG_SERVICE_QSPI)
 	&qspiStorage_,
 #endif
@@ -153,7 +172,7 @@ static struct HSS_Storage *pDefaultStorage = NULL;
 
 #if IS_ENABLED(CONFIG_SERVICE_MMC) || IS_ENABLED(CONFIG_SERVICE_QSPI) || (IS_ENABLED(CONFIG_SERVICE_SPI) && (SPI_FLASH_BOOT_ENABLED))
 struct HSS_BootImage bootImage __attribute__((aligned(8)));
-#elif IS_ENABLED(CONFIG_SERVICE_BOOT_USE_PAYLOAD)
+#elif IS_ENABLED(CONFIG_SERVICE_BOOT_USE_PAYLOAD) || IS_ENABLED(CONFIG_SERVICE_BOOT_SNVM)
 //
 #else
 #    error Unable to determine boot mechanism
@@ -300,7 +319,7 @@ static void printBootImageDetails_(struct HSS_BootImage const * const pBootImage
 }
 #endif
 
-#if IS_ENABLED(CONFIG_SERVICE_BOOT)
+#if IS_ENABLED(CONFIG_SERVICE_BOOT) && (IS_ENABLED(CONFIG_SERVICE_MMC) || IS_ENABLED(CONFIG_SERVICE_QSPI) || IS_ENABLED(CONFIG_SERVICE_SPI))
 static bool copyBootImageToDDR_(struct HSS_BootImage *pBootImage, char *pDest,
     size_t srcOffset, HSS_BootImageCopyFnPtr_t pCopyFunction)
 {
@@ -600,6 +619,99 @@ void HSS_BootSelectSPI(void)
     HSS_Register_Boot_Image(NULL);
 #else
     (void)getBootImageFromSpiFlash_;
+#endif
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+//
+// sNVM Boot Support
+//
+// Read HSS payload from sNVM pages into L2-LIM staging area.
+// Each sNVM page holds 252 bytes (non-authenticated) or 236 bytes (authenticated).
+// Pages are read sequentially and assembled into a contiguous image.
+//
+
+#if IS_ENABLED(CONFIG_SERVICE_BOOT_SNVM)
+#define SNVM_PAGE_SIZE_NON_AUTH  252u
+#define SNVM_MAX_PAGES           221u
+#endif
+
+static bool getBootImageFromSNVM_(struct HSS_Storage *pStorage, struct HSS_BootImage **ppBootImage)
+{
+    bool result = false;
+    (void)pStorage;
+
+#if IS_ENABLED(CONFIG_SERVICE_BOOT) && IS_ENABLED(CONFIG_SERVICE_BOOT_SNVM)
+    assert(ppBootImage);
+
+    const uint8_t startPage = (uint8_t)CONFIG_SERVICE_BOOT_SNVM_START_PAGE;
+    const uint8_t pageCount = (uint8_t)CONFIG_SERVICE_BOOT_SNVM_PAGE_COUNT;
+    uint8_t *pDest = (uint8_t *)(CONFIG_SERVICE_BOOT_SNVM_STAGING_ADDR);
+    uint8_t admin[4];
+    uint16_t status;
+
+    mHSS_DEBUG_PRINTF(LOG_NORMAL, "Reading %u sNVM pages (%u bytes) to 0x%lx ...\n",
+        pageCount, (unsigned)(pageCount * SNVM_PAGE_SIZE_NON_AUTH), (uintptr_t)pDest);
+
+    MSS_SYS_select_service_mode(MSS_SYS_SERVICE_POLLING_MODE, NULL);
+
+    int perf_ctr_index = PERF_CTR_UNINITIALIZED;
+    HSS_PerfCtr_Allocate(&perf_ctr_index, "Boot Image SNVM Read");
+
+    for (uint8_t page = 0u; page < pageCount; page++) {
+        uint8_t moduleIdx = startPage + page;
+
+        if (moduleIdx >= SNVM_MAX_PAGES) {
+            mHSS_DEBUG_PRINTF(LOG_ERROR, "sNVM page %u exceeds max (%u)\n",
+                moduleIdx, SNVM_MAX_PAGES);
+            break;
+        }
+
+        status = MSS_SYS_secure_nvm_read(
+            moduleIdx,
+            NULL,           /* p_user_key: NULL for non-authenticated */
+            admin,          /* p_admin: 4-byte page admin data */
+            pDest,          /* p_data: destination buffer */
+            SNVM_PAGE_SIZE_NON_AUTH,  /* data_len: 252 for non-auth */
+            0u              /* mb_offset */
+        );
+
+        if (status != MSS_SYS_SUCCESS) {
+            mHSS_DEBUG_PRINTF(LOG_ERROR, "sNVM read page %u failed (status=%u)\n",
+                moduleIdx, status);
+            return false;
+        }
+
+        pDest += SNVM_PAGE_SIZE_NON_AUTH;
+    }
+
+    HSS_PerfCtr_Lap(perf_ctr_index);
+
+    mHSS_DEBUG_PRINTF(LOG_NORMAL, "sNVM read complete, verifying magic ...\n");
+
+    *ppBootImage = (struct HSS_BootImage *)(CONFIG_SERVICE_BOOT_SNVM_STAGING_ADDR);
+    result = HSS_Boot_VerifyMagic(*ppBootImage);
+
+    if (result) {
+        printBootImageDetails_(*ppBootImage);
+    } else {
+        mHSS_DEBUG_PRINTF(LOG_ERROR, "sNVM payload magic verification failed\n");
+    }
+#endif
+
+    return result;
+}
+
+void HSS_BootSelectSNVM(void)
+{
+#if IS_ENABLED(CONFIG_SERVICE_BOOT_SNVM)
+    mHSS_DEBUG_PRINTF(LOG_NORMAL, "Selecting SNVM as boot source ...\n");
+    pDefaultStorage = &snvmStorage_;
+#  if IS_ENABLED(CONFIG_SERVICE_BOOT)
+    HSS_Register_Boot_Image(NULL);
+#  endif
+#else
+    (void)getBootImageFromSNVM_;
 #endif
 }
 

--- a/services/boot/Kconfig
+++ b/services/boot/Kconfig
@@ -62,4 +62,48 @@ config SERVICE_BOOT_MMC_USE_GPT
                 parsing of a GUID Partition Table (GPT) in search of the boot image starting
                 sector..
 
+config SERVICE_BOOT_SNVM
+    bool "Boot from sNVM"
+    default n
+    depends on SERVICE_BOOT
+    help
+                This feature enables reading an HSS payload from Secure NVM (sNVM)
+                pages at boot time. The payload is assembled from sequential sNVM
+                pages into an L2-LIM staging area, then processed by the standard
+                HSS boot service. Each sNVM page holds 252 bytes (non-authenticated).
+
+config SERVICE_BOOT_SNVM_START_PAGE
+    int "sNVM start page"
+    default 0
+    depends on SERVICE_BOOT_SNVM
+    help
+                First sNVM page (module index) where the HSS payload is stored.
+                Valid range: 0-220.
+
+config SERVICE_BOOT_SNVM_PAGE_COUNT
+    int "sNVM page count"
+    default 221
+    depends on SERVICE_BOOT_SNVM
+    help
+                Number of sNVM pages to read. Maximum 221 pages (55,692 bytes
+                at 252 bytes per page for non-authenticated format).
+
+config SERVICE_BOOT_SNVM_STAGING_ADDR
+    hex "L2-LIM staging address for sNVM payload"
+    default 0x08100000
+    depends on SERVICE_BOOT_SNVM
+    help
+                Address in L2-LIM where sNVM pages are assembled into a
+                contiguous HSS payload image before boot processing.
+                Must not overlap with HSS resident area or wolfBoot target.
+
+config SERVICE_BOOT_SNVM_MAX_SIZE
+    hex "Maximum sNVM payload size (bytes)"
+    default 0xE000
+    depends on SERVICE_BOOT_SNVM
+    help
+                Maximum size of sNVM payload. Used as YMODEM receive buffer
+                size when DDR is disabled. 221 pages * 252 bytes = 55,692
+                bytes. Default 0xE000 (57,344 bytes) provides headroom.
+
 endmenu

--- a/services/tinycli/tinycli_api.c
+++ b/services/tinycli/tinycli_api.c
@@ -153,6 +153,7 @@ static void tinyCLI_MMC_(void);
 static void tinyCLI_SDCARD_(void);
 static void tinyCLI_Payload_(void);
 static void tinyCLI_SPI_(void);
+static void tinyCLI_SNVM_(void);
 #if IS_ENABLED(CONFIG_SERVICE_USBDMSC) && (IS_ENABLED(CONFIG_SERVICE_MMC) || IS_ENABLED(CONFIG_SERVICE_QSPI))
 static void tinyCLI_USBDMSC_(void);
 #endif
@@ -193,6 +194,7 @@ enum CmdId {
     CMD_USBDMSC,
     CMD_SCRUB,
     CMD_ECC,
+    CMD_SNVM,
     CMD_INVALID,
 
     CMD_DBG_BEU,
@@ -298,6 +300,9 @@ static const struct tinycli_cmd toplevelCmds[] = {
     { CMD_SDCARD,  "SDCARD",  "Select boot via SDCARD.", tinyCLI_SDCARD_ },
     { CMD_PAYLOAD, "PAYLOAD", "Select boot via payload.", tinyCLI_Payload_ },
     { CMD_SPI,     "SPI",     "Select boot via SPI.", tinyCLI_SPI_ },
+#if IS_ENABLED(CONFIG_SERVICE_BOOT_SNVM)
+    { CMD_SNVM,    "SNVM",    "Select boot via sNVM.", tinyCLI_SNVM_ },
+#endif
 #if IS_ENABLED(CONFIG_SERVICE_USBDMSC) && (IS_ENABLED(CONFIG_SERVICE_MMC) || IS_ENABLED(CONFIG_SERVICE_QSPI))
     { CMD_USBDMSC, "USBDMSC", "Export eMMC as USBD Mass Storage Class.", tinyCLI_USBDMSC_ },
 #endif
@@ -330,6 +335,9 @@ static struct tinycli_toplevel_cmd_safe toplevelCmdsSafeAfterBootFlags[] = {
     { CMD_SDCARD,  true },
     { CMD_PAYLOAD, true },
     { CMD_SPI,     true },
+#if IS_ENABLED(CONFIG_SERVICE_BOOT_SNVM)
+    { CMD_SNVM,    true },
+#endif
 #if IS_ENABLED(CONFIG_SERVICE_USBDMSC) && (IS_ENABLED(CONFIG_SERVICE_MMC) || IS_ENABLED(CONFIG_SERVICE_QSPI))
     { CMD_USBDMSC, true },
 #endif
@@ -935,6 +943,15 @@ static void tinyCLI_SPI_(void)
     HSS_BootSelectSPI();
 #else
     tinyCLI_UnsupportedBootMechanism_("SPI");
+#endif
+}
+
+static void tinyCLI_SNVM_(void)
+{
+#if IS_ENABLED(CONFIG_SERVICE_BOOT_SNVM)
+    HSS_BootSelectSNVM();
+#else
+    tinyCLI_UnsupportedBootMechanism_("SNVM");
 #endif
 }
 

--- a/services/ymodem/hss_ymodem_loader.c
+++ b/services/ymodem/hss_ymodem_loader.c
@@ -79,6 +79,11 @@ static bool hss_loader_mmc_init(void);
 static bool hss_loader_mmc_program(uint8_t *pBuffer, size_t wrAddr, size_t receivedCount);
 #endif
 
+#if IS_ENABLED(CONFIG_SERVICE_BOOT_SNVM)
+static bool hss_loader_snvm_program(uint8_t *pBuffer, size_t receivedCount);
+static bool hss_loader_snvm_verify(uint8_t *pBuffer, size_t receivedCount);
+#endif
+
 #if IS_ENABLED(CONFIG_SERVICE_QSPI)
 static bool hss_loader_qspi_init(void)
 {
@@ -126,6 +131,123 @@ bool hss_loader_mmc_program(uint8_t *pBuffer, size_t wrAddr, size_t receivedCoun
 }
 #endif
 
+#if IS_ENABLED(CONFIG_SERVICE_BOOT_SNVM)
+#define SNVM_PAGE_SIZE_NON_AUTH  252u
+#define SNVM_MAX_PAGES           221u
+
+static bool hss_loader_snvm_program(uint8_t *pBuffer, size_t receivedCount)
+{
+    uint8_t startPage = (uint8_t)CONFIG_SERVICE_BOOT_SNVM_START_PAGE;
+    size_t pageCount = (receivedCount + SNVM_PAGE_SIZE_NON_AUTH - 1u) / SNVM_PAGE_SIZE_NON_AUTH;
+    size_t maxPages = (size_t)CONFIG_SERVICE_BOOT_SNVM_PAGE_COUNT;
+    uint16_t status;
+
+    if (pageCount > maxPages) {
+        mHSS_PRINTF("Error: data requires %lu pages but only %lu configured\n",
+            pageCount, maxPages);
+        return false;
+    }
+
+    if ((startPage + pageCount) > SNVM_MAX_PAGES) {
+        mHSS_PRINTF("Error: pages %u-%lu exceed sNVM limit (%u)\n",
+            startPage, startPage + pageCount - 1u, SNVM_MAX_PAGES);
+        return false;
+    }
+
+    MSS_SYS_select_service_mode(MSS_SYS_SERVICE_POLLING_MODE, NULL);
+
+    mHSS_PRINTF("Writing %lu bytes to sNVM pages %u-%lu ...\n",
+        receivedCount, startPage, startPage + pageCount - 1u);
+
+    uint8_t *pSrc = pBuffer;
+    size_t remaining = receivedCount;
+
+    for (size_t i = 0u; i < pageCount; i++) {
+        uint8_t moduleIdx = startPage + (uint8_t)i;
+        uint8_t pageData[SNVM_PAGE_SIZE_NON_AUTH];
+        size_t chunkSize = (remaining >= SNVM_PAGE_SIZE_NON_AUTH) ?
+            SNVM_PAGE_SIZE_NON_AUTH : remaining;
+
+        /* Pad last partial page with 0xFF */
+        memset(pageData, 0xFF, SNVM_PAGE_SIZE_NON_AUTH);
+        memcpy(pageData, pSrc, chunkSize);
+
+        status = MSS_SYS_secure_nvm_write(
+            MSS_SYS_SNVM_NON_AUTHEN_TEXT_REQUEST_CMD,
+            moduleIdx,
+            pageData,
+            NULL,   /* p_user_key: NULL for non-authenticated */
+            0u      /* mb_offset */
+        );
+
+        if (status != MSS_SYS_SUCCESS) {
+            mHSS_PRINTF("\nError: sNVM write page %u failed (status=%u)\n",
+                moduleIdx, status);
+            return false;
+        }
+
+        pSrc += chunkSize;
+        remaining -= chunkSize;
+
+        /* Progress indicator every 10 pages */
+        if ((i % 10u) == 0u) {
+            mHSS_PRINTF("  page %lu/%lu\n", i + 1u, pageCount);
+        }
+    }
+
+    mHSS_PRINTF("sNVM write complete: %lu pages written\n", pageCount);
+    return true;
+}
+
+static bool hss_loader_snvm_verify(uint8_t *pBuffer, size_t receivedCount)
+{
+    uint8_t startPage = (uint8_t)CONFIG_SERVICE_BOOT_SNVM_START_PAGE;
+    size_t pageCount = (receivedCount + SNVM_PAGE_SIZE_NON_AUTH - 1u) / SNVM_PAGE_SIZE_NON_AUTH;
+    uint8_t readData[SNVM_PAGE_SIZE_NON_AUTH];
+    uint8_t admin[4];
+    uint16_t status;
+
+    MSS_SYS_select_service_mode(MSS_SYS_SERVICE_POLLING_MODE, NULL);
+
+    mHSS_PRINTF("Verifying %lu sNVM pages ...\n", pageCount);
+
+    uint8_t *pExpected = pBuffer;
+    size_t remaining = receivedCount;
+
+    for (size_t i = 0u; i < pageCount; i++) {
+        uint8_t moduleIdx = startPage + (uint8_t)i;
+        size_t chunkSize = (remaining >= SNVM_PAGE_SIZE_NON_AUTH) ?
+            SNVM_PAGE_SIZE_NON_AUTH : remaining;
+
+        status = MSS_SYS_secure_nvm_read(
+            moduleIdx,
+            NULL,   /* p_user_key */
+            admin,
+            readData,
+            SNVM_PAGE_SIZE_NON_AUTH,
+            0u      /* mb_offset */
+        );
+
+        if (status != MSS_SYS_SUCCESS) {
+            mHSS_PRINTF("\nError: sNVM read page %u failed (status=%u)\n",
+                moduleIdx, status);
+            return false;
+        }
+
+        if (memcmp(readData, pExpected, chunkSize) != 0) {
+            mHSS_PRINTF("\nError: sNVM verify failed at page %u\n", moduleIdx);
+            return false;
+        }
+
+        pExpected += chunkSize;
+        remaining -= chunkSize;
+    }
+
+    mHSS_PRINTF("sNVM verify OK: %lu pages match\n", pageCount);
+    return true;
+}
+#endif
+
 void hss_loader_ymodem_loop(void);
 void hss_loader_ymodem_loop(void)
 {
@@ -133,11 +255,17 @@ void hss_loader_ymodem_loop(void)
     bool done = false;
 
     uint32_t receivedCount = 0u;
+#if IS_ENABLED(CONFIG_SERVICE_BOOT_SNVM) && IS_ENABLED(CONFIG_SKIP_DDR)
+    /* No DDR available: use L2-LIM staging area for YMODEM receive buffer */
+    uint8_t *pBuffer = (uint8_t *)(CONFIG_SERVICE_BOOT_SNVM_STAGING_ADDR);
+    uint32_t g_rx_size = (uint32_t)CONFIG_SERVICE_BOOT_SNVM_MAX_SIZE;
+#else
     uint8_t *pBuffer = (uint8_t *)HSS_DDR_GetStart();
     uint32_t g_rx_size = HSS_DDR_GetSize();
+#endif
 
     while (!done) {
-#if IS_ENABLED(CONFIG_SERVICE_QSPI) || IS_ENABLED(CONFIG_SERVICE_MMC)
+#if IS_ENABLED(CONFIG_SERVICE_QSPI) || IS_ENABLED(CONFIG_SERVICE_MMC) || IS_ENABLED(CONFIG_SERVICE_BOOT_SNVM)
         bool result = false;
 #endif
         static const char menuText[] = "\n"
@@ -149,6 +277,9 @@ void hss_loader_ymodem_loop(void)
 #endif
 #if IS_ENABLED(CONFIG_SERVICE_MMC)
            "MMC"
+#endif
+#if IS_ENABLED(CONFIG_SERVICE_BOOT_SNVM)
+           "/sNVM"
 #endif
            " Utility\n"
 #if IS_ENABLED(CONFIG_SERVICE_QSPI)
@@ -164,8 +295,12 @@ void hss_loader_ymodem_loop(void)
 #if IS_ENABLED(CONFIG_SERVICE_MMC)
             " 5. MMC Write -- write application file to the Device\n"
 #endif
-            " 6. Quit -- quit QSPI Utility\n\n"
-            " Select a number:\n";
+            " 6. Quit -- quit Utility\n"
+#if IS_ENABLED(CONFIG_SERVICE_BOOT_SNVM)
+            " 7. sNVM Write -- write received file to sNVM pages\n"
+            " 8. sNVM Verify -- verify sNVM contents against received file\n"
+#endif
+            "\n Select a number:\n";
 
         mHSS_PUTS(menuText);
 
@@ -275,6 +410,38 @@ void hss_loader_ymodem_loop(void)
             case '6':
                 done = true;
                 break;
+
+#if IS_ENABLED(CONFIG_SERVICE_BOOT_SNVM)
+            case '7':
+                if (receivedCount == 0u) {
+                    mHSS_PUTS("\nNo data received. Use option 3 (YMODEM Receive) first.\n");
+                } else {
+                    mHSS_PRINTF("\nWriting %u bytes to sNVM ...\n", receivedCount);
+                    result = hss_loader_snvm_program(pBuffer, receivedCount);
+
+                    if (!result) {
+                        HSS_Debug_Highlight(HSS_DEBUG_LOG_ERROR);
+                        mHSS_PUTS(" sNVM Write FAILED\n");
+                        HSS_Debug_Highlight(HSS_DEBUG_LOG_NORMAL);
+                    }
+                }
+                break;
+
+            case '8':
+                if (receivedCount == 0u) {
+                    mHSS_PUTS("\nNo data received. Use option 3 (YMODEM Receive) first.\n");
+                } else {
+                    mHSS_PRINTF("\nVerifying %u bytes against sNVM ...\n", receivedCount);
+                    result = hss_loader_snvm_verify(pBuffer, receivedCount);
+
+                    if (!result) {
+                        HSS_Debug_Highlight(HSS_DEBUG_LOG_ERROR);
+                        mHSS_PUTS(" sNVM Verify FAILED\n");
+                        HSS_Debug_Highlight(HSS_DEBUG_LOG_NORMAL);
+                    }
+                }
+                break;
+#endif
 
             default: // ignore
                 break;


### PR DESCRIPTION
# Description

This PR adds support for booting the HSS from Secure NVM (sNVM) pages on PolarFire SoC. The sNVM is a small, persistent, non-volatile memory embedded in the PolarFire SoC fabric that does not require an external flash device. This enables a boot path that is independent of QSPI, eMMC, or SD card, suitable for designs where no DDR or external storage is available at boot time.

The implementation reads sequential sNVM pages (252 bytes each in non-authenticated format) into an L2-LIM staging area and feeds the assembled image to the standard HSS boot service. A new `CONFIG_SERVICE_BOOT_SNVM` Kconfig option gates the feature. Supporting Kconfig options allow configuring the start page, page count, staging address, and maximum payload size.

YMODEM programmer support is also extended with two new menu options (sNVM Write and sNVM Verify) so that payloads can be loaded into sNVM interactively via the HSS UART console. When `CONFIG_SKIP_DDR` is set, the YMODEM receive buffer is redirected to the L2-LIM staging area instead of DDR.

A reference defconfig (`def_config_wolfboot_snvm`) and linker script (`hss-l2scratch.ld`) for the mpfs-video-kit board are included as a starting point for sNVM + wolfBoot configurations.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Test A: HSS built with `def_config_wolfboot_snvm` on mpfs-video-kit. YMODEM console used to write a wolfBoot HSS payload to sNVM pages. Board power-cycled; HSS successfully read payload from sNVM and handed off to wolfBoot.
- [x] Test B: sNVM Verify option (menu item 8) confirmed written pages match the transferred file byte-for-byte.
- [ ] Test C: Boot tested without DDR (`CONFIG_SKIP_DDR`) using L2-LIM as YMODEM receive buffer.

**Test Configuration**:
* Reference design release: <!-- e.g. 2024.09 -->
* Hardware: mpfs-video-kit
* HSS version: <!-- tag or commit sha -->
* Bare metal examples version: N/A
* Buildroot / Yocto release: N/A (wolfBoot payload only)

# Checklist:

- [x] I have reviewed my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
- [ ] I have added a maintainers file for any new board support
