### PR TITLE
mmc: Use cmd12 to abort during MMC phy training. Support default speed

### DIFF
--- a/baremetal/polarfire-soc-bare-metal-library/src/platform/drivers/mss/mss_mmc/mss_mmc.c
+++ b/baremetal/polarfire-soc-bare-metal-library/src/platform/drivers/mss/mss_mmc/mss_mmc.c
@@ -62,6 +62,7 @@ extern "C" {
 #define MMC_SOFTWARE_RESET_SHIFT        0x3u
 #define DEBOUNCING_TIME                 0x300000u
 #define MMC_RESET_DATA_CMD_LINE         0x06000000u
+#define CMD_TYPE_ABORT                  0xC0u
 /* SDMA boundary is 512k */
 #define SIZE_32MB                       0x02000000u
 #define SIZE_64KB                       0x00010000u
@@ -1370,11 +1371,9 @@ static mss_mmc_status_t phy_training_mmc(uint8_t delay_type, uint32_t clk_rate)
     uint8_t pos, length, curr_length;
     uint8_t rx_buff[BLK_SIZE];
     uint32_t read_srs11;
-    uint32_t cmd_response;
-    mMMC_DECLARE_TIMEOUT(mmc_spin_timeout);
+    uint32_t read_srs12;
 
     mss_mmc_status_t ret_status = MSS_MMC_NO_ERROR;
-    cif_response_t response_status = TRANSFER_IF_FAIL;
 
     if (clk_rate <= MSS_MMC_CLOCK_12_5MHZ)
     {
@@ -1406,33 +1405,35 @@ static mss_mmc_status_t phy_training_mmc(uint8_t delay_type, uint32_t clk_rate)
         }
         else
         {
+            mMMC_DECLARE_TIMEOUT(mmc_spin_timeout);
             mMMC_ARM_TIMEOUT(mmc_spin_timeout);
+            /* Reset Data and cmd line */
+            MMC->SRS11 |= MMC_RESET_DATA_CMD_LINE;
             do
             {
-                if (TRANSFER_IF_FAIL == response_status)
-                {
-                    /* Reset Data and cmd line */
-                    MMC->SRS11 |= MMC_RESET_DATA_CMD_LINE;
-
-                    mMMC_DECLARE_TIMEOUT(mmc_spin_timeout2);
-                    mMMC_ARM_TIMEOUT(mmc_spin_timeout2);
-                    do
-                    {
-                        read_srs11 = MMC->SRS11;
-                        mMMC_CHECK_TIMEOUT(mmc_spin_timeout2, MSS_MMC_NOT_INITIALISED);
-                    } while ((read_srs11 & MMC_RESET_DATA_CMD_LINE) != MMC_CLEAR);
-                }
-
-                response_status = cif_send_cmd(sdcard_RCA << RCA_SHIFT_BIT,
-                                            MMC_CMD_13_SEND_STATUS,
-                                            MSS_MMC_RESPONSE_R1);
-                cmd_response = MMC->SRS04;
+                read_srs11 = MMC->SRS11;
                 mMMC_CHECK_TIMEOUT(mmc_spin_timeout, MSS_MMC_NOT_INITIALISED);
-            } while ((TRANSFER_IF_SUCCESS != response_status) ||
-                    ((cmd_response & DEVICE_STATE_MASK) != DEVICE_STATE_TRANS));
+            } while ((read_srs11 & MMC_RESET_DATA_CMD_LINE) != MMC_CLEAR);
 
+            /* Execute CMD12 command to abort command */
+            send_mmc_cmd(sdcard_RCA << RCA_SHIFT_BIT,
+                            MMC_CMD_12_STOP_TRANSMISSION | CMD_TYPE_ABORT,
+                            MSS_MMC_RESPONSE_R1B, CHECK_IF_CMD_SENT_POLL);
+            read_srs12 = MMC->SRS12;
+            if ((SRS12_COMMAND_COMPLETE != (read_srs12 & SRS12_COMMAND_COMPLETE)) ||
+                (MMC_CLEAR != (read_srs12 & SRS12_ERROR_INTERRUPT)))
+            {
+                mMMC_DECLARE_TIMEOUT(mmc_spin_timeout2);
+                mMMC_ARM_TIMEOUT(mmc_spin_timeout2);
+                /* Reset Data and cmd line */
+                MMC->SRS11 |= MMC_RESET_DATA_CMD_LINE;
+                do
+                {
+                    read_srs11 = MMC->SRS11;
+                    mMMC_CHECK_TIMEOUT(mmc_spin_timeout2, MSS_MMC_NOT_INITIALISED);
+                } while ((read_srs11 & MMC_RESET_DATA_CMD_LINE) != MMC_CLEAR);
+            }
             curr_length = MMC_CLEAR;
-            response_status = TRANSFER_IF_FAIL;
         }
     }
 
@@ -2027,14 +2028,14 @@ static mss_mmc_status_t sdcard_oper_config(const mss_mmc_cfg_t * cfg)
                                                         response_status = TRANSFER_IF_FAIL;
                                                     }
                                                     break;
-                                                case MSS_MMC_PHY_DELAY_INPUT_HIGH_SPEED:
+                                                case MSS_SDCARD_MODE_HIGH_SPEED:
                                                     ret_status = phy_training_mmc(MSS_MMC_PHY_DELAY_INPUT_HIGH_SPEED, cfg->clk_rate);
                                                     if (ret_status != MSS_MMC_TRANSFER_SUCCESS)
                                                     {
                                                         response_status = TRANSFER_IF_FAIL;
                                                     }
                                                     break;
-
+                                                case MSS_SDCARD_MODE_DEFAULT_SPEED:
                                                 default:
                                                     ret_status = phy_training_mmc(MSS_MMC_PHY_DELAY_INPUT_DEFAULT_SPEED, cfg->clk_rate);
                                                     if (ret_status != MSS_MMC_TRANSFER_SUCCESS)

--- a/services/mmc/mmc_api.c
+++ b/services/mmc/mmc_api.c
@@ -190,10 +190,11 @@ static bool mmc_init_sdcard(void)
         .data_bus_width = MSS_MMC_DATA_WIDTH_4BIT,
 #if IS_ENABLED(CONFIG_SERVICE_MMC_DEFAULT_SPEED)
         .bus_speed_mode = MSS_SDCARD_MODE_DEFAULT_SPEED,
+        .clk_rate = MSS_MMC_CLOCK_25MHZ,
 #else
         .bus_speed_mode = MSS_SDCARD_MODE_HIGH_SPEED,
-#endif
         .clk_rate = MSS_MMC_CLOCK_50MHZ,
+#endif
     };
 
 


### PR DESCRIPTION
# Description

Implemented part of the recovery action inside the MMC phy training from the latest platform code [mss_mmc.c:#L1781-L1860](https://github.com/polarfire-soc/platform/blob/9011c280851c0d4d00b8d17ccc404246354fe09c/drivers/mss/mss_mmc/mss_mmc.c#L1781-L1860).
Specifically it adds the following routine:
```c
    send_mmc_cmd(sdcard_RCA << SHIFT_16BIT, MMC_CMD_12_STOP_TRANSMISSION | CMD_TYPE_ABORT,
                MSS_MMC_RESPONSE_R1B, CHECK_IF_CMD_SENT_POLL);
```
and removes requirement to wait on a successful transfer `DEVICE_STATE_TRANS` and `TRANSFER_IF_SUCCESS` which causes a timeout/loop when the MMC is still being set up.

Also resolved incorrect case statement for the phy training resolution.

Likely fixes #79. I observed that the disco kit would only cold boot from HIGH_SPEED and not from DEFAULT_SPEED. In DEFAULT_SPEED it locks up then times out.
```
[4.96209] CLI boot interrupt timeout
[4.101078] loop 272900 took 606472775 ticks (max 606472775 ticks)
[4.109003] Initializing Boot Image ...
[4.114064] Trying to get boot image via MMC ...
[4.119983] Attempting to select SDCARD ... Failed
[17.186222] loop 272901 took 7846275423 ticks (max 7846275423 ticks)
```

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Executed HIGH_SPEED boot from `mpfs-disco-kit` into reference linux SD Card image 2026.04
- [X] Executed DEFAULT_SPEED boot from `mpfs-disco-kit` into reference linux SD Card image 2026.04
- [ ] Someone should test with EMMC just to make sure that doesn't break

# Checklist:

- [X] I have reviewed my code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have tested that my fix is effective or that my feature works
