### PR TITLE
fix(ymodem): Route to HSS UART instead of UART0

### DIFF
--- a/services/ymodem/ymodem_protocol.c
+++ b/services/ymodem/ymodem_protocol.c
@@ -73,8 +73,6 @@ enum XYModem_Signals {
 
 /***************************************************************************/
 
-mss_uart_instance_t *g_my_uart = &g_mss_uart0_lo;
-
 static int16_t getchar_with_timeout_(int32_t timeout_sec)
 {
     uint8_t rx_byte = 0;
@@ -93,7 +91,8 @@ static int16_t getchar_with_timeout_(int32_t timeout_sec)
 
 static void putchar_(uint8_t tx_byte)
 {
-    MSS_UART_polled_tx(g_my_uart, &tx_byte, 1);
+    mss_uart_instance_t *pUart = HSS_UART_GetInstance(HSS_HART_E51);
+    MSS_UART_polled_tx(pUart, &tx_byte, 1);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# Description

ymodem was hard-coded to use uart0. Now correctly retrieves hss-defined uart instance

Fixes:

ymodem works on boards that don't use uart0 for HSS console (e.g. disco kit)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Executed ymodem transfer using tera term with disco kit

**Test Configuration**:
* Reference design release: v2026.04
* Hardware: Discovery Kit
* HSS version: v2026.04.1
* Bare metal examples version: N/A
* Buildroot / Yocto release: N/A

# Checklist:

- [X] I have reviewed my code
- [X] My changes generate no new warnings
- [X] I have tested that my fix is effective or that my feature works
