### PR TITLE
Fixed build error in case of CONFIG_SKIP_DDR=y

### DIFF
--- a/services/opensbi/platform.c
+++ b/services/opensbi/platform.c
@@ -690,14 +690,14 @@ u32 mpfs_get_suspended_hartid(void)
     return suspended_hartid;
 }
 
-#ifndef CONFIG_SKIP_DDR
+#if !IS_ENABLED(CONFIG_SKIP_DDR)
 extern void mpfs_hal_turn_ddr_selfrefresh_on(void);
 extern void mpfs_hal_turn_ddr_selfrefresh_off(void);
 #endif
 
 void mpfs_system_suspend(void)
 {
-#ifndef CONFIG_SKIP_DDR
+#if !IS_ENABLED(CONFIG_SKIP_DDR)
     volatile uint32_t * const self_refresh_status_reg =
         (volatile uint32_t *)(MSS_DDRC_BASE_ADDR + MSS_DDRC_SELF_REFRESH_STATUS_OFFSET);
     mpfs_hal_turn_ddr_selfrefresh_on();
@@ -710,7 +710,7 @@ void mpfs_system_suspend(void)
 
 void mpfs_system_resume(void)
 {
-#ifndef CONFIG_SKIP_DDR
+#if !IS_ENABLED(CONFIG_SKIP_DDR)
     volatile uint32_t * const self_refresh_status_reg =
         (volatile uint32_t *)(MSS_DDRC_BASE_ADDR + MSS_DDRC_SELF_REFRESH_STATUS_OFFSET);
     mpfs_hal_turn_ddr_selfrefresh_off();

--- a/services/opensbi/platform.c
+++ b/services/opensbi/platform.c
@@ -690,11 +690,14 @@ u32 mpfs_get_suspended_hartid(void)
     return suspended_hartid;
 }
 
+#ifndef CONFIG_SKIP_DDR
 extern void mpfs_hal_turn_ddr_selfrefresh_on(void);
 extern void mpfs_hal_turn_ddr_selfrefresh_off(void);
+#endif
 
 void mpfs_system_suspend(void)
 {
+#ifndef CONFIG_SKIP_DDR
     volatile uint32_t * const self_refresh_status_reg =
         (volatile uint32_t *)(MSS_DDRC_BASE_ADDR + MSS_DDRC_SELF_REFRESH_STATUS_OFFSET);
     mpfs_hal_turn_ddr_selfrefresh_on();
@@ -702,10 +705,12 @@ void mpfs_system_suspend(void)
         ; // poll INIT_SELF_REFRESH_STATUS bit until DDRC ACKs entry
     }
     mHSS_DEBUG_PRINTF(LOG_WARN, "%s: self_refresh active\n", __func__);
+#endif
 }
 
 void mpfs_system_resume(void)
 {
+#ifndef CONFIG_SKIP_DDR
     volatile uint32_t * const self_refresh_status_reg =
         (volatile uint32_t *)(MSS_DDRC_BASE_ADDR + MSS_DDRC_SELF_REFRESH_STATUS_OFFSET);
     mpfs_hal_turn_ddr_selfrefresh_off();
@@ -714,6 +719,7 @@ void mpfs_system_resume(void)
     }
 
     mHSS_DEBUG_PRINTF(LOG_WARN, "%s: self_refresh inactive\n", __func__);
+#endif
 }
 
 const struct sbi_hsm_device mpfs_hsm = {


### PR DESCRIPTION
# Description

The OpenSBI system suspend/resume path in `services/opensbi/platform.c` unconditionally called `mpfs_hal_turn_ddr_selfrefresh_on()` / `mpfs_hal_turn_ddr_selfrefresh_off()` and polled the DDRC self-refresh status register. Those functions are provided by `mss_ddr.c`, which the baremetal Makefile only compiles when `CONFIG_SKIP_DDR` is **not** set (`baremetal/Makefile`, `ifndef CONFIG_SKIP_DDR`).

On boards configured with `CONFIG_SKIP_DDR=y`, `mss_ddr.c` is excluded, so linking failed with:

```
undefined reference to `mpfs_hal_turn_ddr_selfrefresh_on'
undefined reference to `mpfs_hal_turn_ddr_selfrefresh_off'
```

This change wraps the DDR self-refresh logic (the `extern` declarations and the bodies of `mpfs_system_suspend()` / `mpfs_system_resume()`) in `#ifndef CONFIG_SKIP_DDR`, matching the condition the build system already uses. On DDR-less boards the functions become no-ops; on DDR boards behavior is unchanged. This also avoids a latent hang: simply removing the `_on()` call while leaving the ACK-bit poll loop would spin forever, since self-refresh is never enabled.

No new dependencies.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Build (`CONFIG_SKIP_DDR=y`): links successfully; previously failed at `LD hss-l2scratch.elf`.
- [ ] Build  (`CONFIG_SKIP_DDR` not set): confirm self-refresh path still compiles and links unchanged.

**Test Configuration**:
* Reference design release: 2025.07
* Hardware: Custom
* HSS version: v2026.04.1
* Bare metal examples version: NA
* Buildroot / Yocto release: NA

# Checklist:

- [x] I have reviewed my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
- [ ] I have added a maintainers file for any new board support
