### PR TITLE
Fixed array-bounds error in mss_ddr.c

### DIFF
--- a/baremetal/polarfire-soc-bare-metal-library/src/platform/mpfs_hal/common/nwc/mss_ddr.c
+++ b/baremetal/polarfire-soc-bare-metal-library/src/platform/mpfs_hal/common/nwc/mss_ddr.c
@@ -5165,35 +5165,35 @@ static uint32_t zq_cal(void)
 }
 #endif
 
-uint32_t ddr_add_cmd_inc_feq[]={\
+uint32_t ddr_add_cmd_inc_feq[DDR_OFF_MODE + 1U]={\
         ADD_CMD_INC_FREQ_DDR3,\
         ADD_CMD_INC_FREQ_DDR3L,\
         ADD_CMD_INC_FREQ_DDR4,\
         ADD_CMD_INC_FREQ_LPDDR3,\
         ADD_CMD_INC_FREQ_LPDDR4 };
 
-uint32_t ddr_add_cmd_trans_a5_threshold[]={\
+uint32_t ddr_add_cmd_trans_a5_threshold[DDR_OFF_MODE + 1U]={\
         ADD_CMD_TRANS_A5_THRES_DDR3,\
         ADD_CMD_TRANS_A5_THRES_DDR3L,\
         ADD_CMD_TRANS_A5_THRES_DDR4,\
         ADD_CMD_TRANS_A5_THRES_LPDDR3,\
         ADD_CMD_TRANS_A5_THRES_LPDDR4 };
 
-uint32_t add_cmd_move_order_0_deg[]={\
+uint32_t add_cmd_move_order_0_deg[DDR_OFF_MODE + 1U]={\
         LIBERO_SETTING_ADD_CMD_CLK_MOVE_ORDER_0_DEG_DDR3,\
         LIBERO_SETTING_ADD_CMD_CLK_MOVE_ORDER_0_DEG_DDR3L,\
         LIBERO_SETTING_ADD_CMD_CLK_MOVE_ORDER_0_DEG_DDR4,\
         LIBERO_SETTING_ADD_CMD_CLK_MOVE_ORDER_0_DEG_LPDDR3,\
         LIBERO_SETTING_ADD_CMD_CLK_MOVE_ORDER_0_DEG_LPDDR4 };
 
-uint32_t add_cmd_move_order_45_deg[]={\
+uint32_t add_cmd_move_order_45_deg[DDR_OFF_MODE + 1U]={\
         LIBERO_SETTING_ADD_CMD_CLK_MOVE_ORDER_45_DEG_DDR3,\
         LIBERO_SETTING_ADD_CMD_CLK_MOVE_ORDER_45_DEG_DDR3L,\
         LIBERO_SETTING_ADD_CMD_CLK_MOVE_ORDER_45_DEG_DDR4,\
         LIBERO_SETTING_ADD_CMD_CLK_MOVE_ORDER_45_DEG_LPDDR3,\
         LIBERO_SETTING_ADD_CMD_CLK_MOVE_ORDER_45_DEG_LPDDR4 };
 
-uint32_t add_cmd_move_order_90_deg[]={\
+uint32_t add_cmd_move_order_90_deg[DDR_OFF_MODE + 1U]={\
         LIBERO_SETTING_ADD_CMD_CLK_MOVE_ORDER_90_DEG_DDR3,\
         LIBERO_SETTING_ADD_CMD_CLK_MOVE_ORDER_90_DEG_DDR3L,\
         LIBERO_SETTING_ADD_CMD_CLK_MOVE_ORDER_90_DEG_DDR4,\


### PR DESCRIPTION
# Description

This PR fixes a build failure in the MPFS HAL DDR code when compiling with the current toolchain (riscv-none-elf-gcc 15.2.0), whose stricter `-Werror=array-bounds` diagnostic rejects an out-of-bounds array index in the DDR training tables.

In `mpfs_hal/common/nwc/mss_ddr.c`, five tables indexed by `ddr_type` were declared with 5 elements (`DDR3`..`LPDDR4`), but the `DDR_TYPE` enum's highest value is `DDR_OFF_MODE = 0x07`. GCC 15 proves `ddr_type` can be `7` and fails the build with:

```
error: array subscript 7 is above array bounds of 'uint32_t[5]' [-Werror=array-bounds=]
```

The affected tables are `ddr_add_cmd_inc_feq`, `ddr_add_cmd_trans_a5_threshold`, `add_cmd_move_order_0_deg`, `add_cmd_move_order_45_deg`, and `add_cmd_move_order_90_deg`.

Fix: size the tables `[DDR_OFF_MODE + 1U]` so indexing by any `DDR_TYPE` value is in-bounds. Indices `0..4` keep their per-DDR-type settings; the higher slots are zero and are never read at runtime (training only runs for a real DDR type). `DDR_OFF_MODE` keeps its hardware-encoded value `0x07`, since it is compared against the raw `DDRPHY_MODE` register field and must not be renumbered. `-Werror` remains enabled for the file.

No new dependencies.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Full build with riscv-none-elf-gcc 15.2.0: compiles and links successfully (previously failed at `CC .../mss_ddr.o` with `-Werror=array-bounds`).
- [x] No new compiler warnings introduced; `-Werror` remains enabled.

**Test Configuration**:
* Reference design release: 2025.07
* Hardware: Custom MPFS095
* HSS version: 2026.04.1
* Bare metal examples version: NA
* Buildroot / Yocto release: NA

# Checklist:

- [x] I have reviewed my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
- [ ] I have added a maintainers file for any new board support
